### PR TITLE
Add `docker-build-push` action

### DIFF
--- a/.github/actions/docker-build-push/README.md
+++ b/.github/actions/docker-build-push/README.md
@@ -1,0 +1,38 @@
+# Docker Build and Push Action
+
+This action builds and pushes a Docker image to a container repository.
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| container-registry | string | Name of the container registry to push the image to | true | N/A | 'ghcr.io' |
+| image-name | string | Name of the image to push (-t) | true | N/A | 'example-image:latest' |
+| dockerfile-directory | string | Location of the Dockerfile | false | '.' | 'containers/' |
+| dockerfile-name | string | Name of the Dockerfile that will be built | false | 'Dockerfile' | 'Dockerfile.prod' |
+| build-args | string | List of Docker build arguments (--build-arg) | false | '' | 'VAR=value' |
+| build-secrets | string | List of docker build secrets (--secret) | false | '' | 'KEY=abcd' |
+| target | string | Build target for the Dockerfile | false | '' | 'ci' |
+| push | string | Whether the built image should be pushed to the container repository | false | 'true' | 'true' |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| image-url| string | Full path of the built image | 'ghcr.io/access-nri/image:tag' |
+
+## Example
+
+```yaml
+# ...
+- uses: access-nri/actions/.github/actions/docker-build-push@main
+  with:
+    container-repository: ghcr.io
+    image-name: my-image:latest
+    build-args: |
+      VAR1=value1
+      VAR2=value2
+    build-secrets: |
+      SECRET1=${{ secrets.SECRET1 }}
+      SECRET2=${{ secrets.SECRET2 }}
+```

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,0 +1,85 @@
+name: Docker
+inputs:
+  container-registry:
+    required: true
+    type: string
+    description: Name of the container registry to push the image to
+  image-name:
+    required: true
+    type: string
+    description: Name of the image to push (-t)
+  dockerfile-directory:
+    required: false
+    default: '.'
+    type: string
+    description: Location of the dockerfile
+  dockerfile-name:
+    required: false
+    default: 'Dockerfile'
+    type: string
+    description: Name of the Dockerfile that will be built
+  build-args:
+    required: false
+    type: string
+    default: ""
+    description: List of Docker build arguments (--build-arg)
+  target:
+    required: false
+    type: string
+    default: ""
+    description: Build target string (--target)
+  build-secrets:
+    required: false
+    default: ""
+    description: List of Docker build secrets (--secret)
+  push:
+    required: false
+    default: true
+    description: Whether the built image should be pushed (defaults to 'true')
+outputs:
+  image-url:
+    description: Full built image URL <container-registry>/<image-name>
+    value: ${{ steps.image.outputs.path }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Buildx is currently required to use a subdirectory w/ build-push-action
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.container-registry }}
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ inputs.container-registry }}/${{ inputs.image-name }}
+        flavor: |
+          latest=true
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v3
+      with:
+        context: "{{defaultContext}}:${{ inputs.dockerfile-directory }}"
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.build-secrets }}
+        file: ${{ inputs.dockerfile-name }}
+        push: ${{ inputs.push }}
+        target: ${{ inputs.target }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Output image path
+      shell: bash
+      id: image
+      run: echo "path=${{ inputs.container-registry }}/${{ inputs.image-name }}" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Custom GitHub Actions for use across the ACCESS-NRI.
 ## Actions
 
 * `setup-ssh`: Sets up private keys and ~/.ssh/known_hosts: [setup-ssh README.md](.github/actions/setup-ssh/README.md). 
+* `docker-build-push`: Builds and pushes a docker image: [docker-build-push README.md](.github/actions/docker-build-push/README.md).
 
 ## Workflows
 
 * `validate-json.yml`: Runs a matrix job that validates all the `*.json`/`*.schema.json`: [validate-json README.md](.github/workflows/README.md).
-


### PR DESCRIPTION
Addition of a new action that replaces the old `build-ci` workflow for building and pushing docker images. 