### PR TITLE
Added new `react-to-comment` action

### DIFF
--- a/.github/actions/react-to-comment/README.md
+++ b/.github/actions/react-to-comment/README.md
@@ -12,6 +12,7 @@ This action adds a reaction to a given comment, or alternatively the comment ref
 | `reaction` | `string` | The reaction to the given comment in GitHubs Emoji syntax | `true` | `"+1"` | `"rocket"` |
 | `repository` | `string` | The GitHub `OWNER/REPO` combination | `false` | `${{ github.repository }}` | `"ACCESS-NRI/actions"` |
 | `comment-id` | `number` | The `COMMENT_ID` of the issue/pull request comment | `false` | `${{ github.event.comment.id }}` | `1234567` |
+| `token` | `string` | Appropriate Github Token/PAT to react to the given comment | `true` | N/A | `${{ secrets.GITHUB_TOKEN }}` |
 
 ## Example
 
@@ -20,4 +21,5 @@ This action adds a reaction to a given comment, or alternatively the comment ref
 - uses: access-nri/actions/.github/actions/react-to-comment@main
   with:
     reaction: rocket
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/.github/actions/react-to-comment/README.md
+++ b/.github/actions/react-to-comment/README.md
@@ -1,0 +1,23 @@
+# React To Comment Action
+
+This action adds a reaction to a given comment, or alternatively the comment referred to by the `on.issue_comment` trigger. Reactions are defined in [GitHub's Emoji syntax](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment).
+
+> [!NOTE]
+> Ensure the job has the correct permissions for the type of comment reaction (either `permissions.issues:write` or `permissions.pull-request:write`).
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `reaction` | `string` | The reaction to the given comment in GitHubs Emoji syntax | `true` | `"+1"` | `"rocket"` |
+| `repository` | `string` | The GitHub `OWNER/REPO` combination | `false` | `${{ github.repository }}` | `"ACCESS-NRI/actions"` |
+| `comment-id` | `number` | The `COMMENT_ID` of the issue/pull request comment | `false` | `${{ github.event.comment.id }}` | `1234567` |
+
+## Example
+
+```yaml
+# ...
+- uses: access-nri/actions/.github/actions/react-to-comment@main
+  with:
+    reaction: rocket
+```

--- a/.github/actions/react-to-comment/action.yml
+++ b/.github/actions/react-to-comment/action.yml
@@ -1,0 +1,29 @@
+name: React to Comment
+description: Action that reacts to a given comment, or alternatively the comment referred to by the on.issue_comment trigger.
+inputs:
+  reaction:
+    type: string
+    required: true
+    default: '+1'
+    description: The reaction to the given comment in GitHubs Emoji syntax. Currently supports +1, -1, laugh, confused, heart, hooray, rocket and eyes.
+  repository:
+    type: string
+    required: false
+    description: The GitHub OWNER/REPO combination. Defaults to github.repository of the caller
+  comment-id:
+    type: number
+    required: false
+    description: The COMMENT_ID of the issue/pull request comment. Defaults to the github.event.comment.id of the caller
+runs:
+  using: "composite"
+  steps:
+    - env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+          -f content='rocket'

--- a/.github/actions/react-to-comment/action.yml
+++ b/.github/actions/react-to-comment/action.yml
@@ -14,11 +14,15 @@ inputs:
     type: number
     required: false
     description: The COMMENT_ID of the issue/pull request comment. Defaults to the github.event.comment.id of the caller
+  token:
+    type: string
+    required: true
+    description: GitHub token/PAT that has the appropriate permissions to react to the comment
 runs:
   using: "composite"
   steps:
     - env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.token }}
       shell: bash
       run: |
         gh api \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Custom GitHub Actions for use across the ACCESS-NRI.
 * `setup-ssh`: Sets up private keys and ~/.ssh/known_hosts: [setup-ssh README.md](.github/actions/setup-ssh/README.md).
 * `docker-build-push`: Builds and pushes a docker image: [docker-build-push README.md](.github/actions/docker-build-push/README.md).
 * `bump-version`: Bumps a version string given a versioning scheme: [bump-version README.md](.github/actions/bump-version/README.md).
+* `react-to-comment`: Lets `github-actions[bot]` react to a comment. Usually useful to let users know there is some action in progress: [react-to-comment](.github/actions/react-to-comment/README.md).
 
 ## Workflows
 


### PR DESCRIPTION
Action that wraps a call using the `gh api` command. 
Useful for a bot to give a reaction to a comment that triggers a workflow - just so users have visibility that something is happening in the background. 