### PR TITLE
Added `pr-comment` Action

### DIFF
--- a/.github/actions/pr-comment/README.md
+++ b/.github/actions/pr-comment/README.md
@@ -1,0 +1,61 @@
+# PR Comment Action
+
+This action comments on a given PR as `github-actions[bot]`.
+
+> ![NOTE]
+> Requires `permissions.issues:write` or `permissions.pull-requests:write` depending on what you want commented
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `comment` | `string` | The body of the comment, in GitHub Markdown format | `true` | N/A | `"Hello this is a comment from PR 20"` |
+| `pr` | `number` | The Pull Request Number that will be commented on | `false` | `github.event.[pull_request\|issue].number` | `20` |
+| `edit-last` | `boolean` | Edit the last comment by `github-actions[bot]` instead of creating a new one | `false` | `false` | `true` |
+| `token` | `string` | A GitHub Token/PAT that allows commenting on the given PR | `false` | `github.token` | `gha_pat_abcds...` |
+
+outputs:
+  comment-link:
+    description:
+    value: ${{ steps.comment.outputs.link }}
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `comment-link` | `string` | A link to the added comment | `https://github.com/OWNER/REPO/pull/PR#issuecomment-ID` |
+
+## Examples
+
+```yaml
+# ...
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: access-nri/actions/.github/actions/pr-comment@main
+      with:
+        comment: |
+          Wow, a comment on PR `${{ github.event.pull_request.number }}`!
+          With multilines!
+```
+
+```yaml
+# ...
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: access-nri/actions/.github/actions/pr-comment@main
+      with:
+        pr: 123
+        token: ${{ secrets.MY_PAT }}
+        edit-last: true
+        comment: |
+          Wow, a comment on PR `123`!
+          With multilines!
+```

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -1,0 +1,67 @@
+name: PR Comment
+description: Action that comments on a given PR
+inputs:
+  comment:
+    type: string
+    required: true
+    description: The body of the comment, in GitHub Markdown format
+  pr:
+    type: number
+    required: false
+    description: The Pull Request Number that will be commented on. Defaults to the PR associated with the callers event
+  edit-last:
+    type: boolean
+    required: false
+    default: false
+    description: Edit the last comment by 'github-actions[bot]' instead of creating a new one
+  token:
+    type: string
+    required: false
+    description: A GitHub Token/PAT that allows commenting on the given PR. Defaults to github.token
+outputs:
+  comment-link:
+    description: A link to the added comment
+    value: ${{ steps.comment.outputs.link }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set Non-Required Inputs
+      shell: bash
+      run: |
+        # Set PR
+        if [[ -z "${{ inputs.pr }}" ]]; then
+          if [[ -n "${{ github.event.issue }}" ]]; then
+            echo "PR=${{ github.event.issue.number }}" >> $GITHUB_ENV
+          elif [[ -n "${{ github.event.pull_request }}" ]]; then
+            echo "PR=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          else
+            echo "::error::Couldn't infer PR number from event payload, please enter as an input"
+            exit 1
+          fi
+        else
+          echo "PR=${{ inputs.pr }}" >> $GITHUB_ENV
+        fi
+
+        # Set GH_TOKEN
+        if [[ -z "${{ inputs.token }}" ]]; then
+          echo "GH_TOKEN=${{ github.token }}" >> $GITHUB_ENV
+        else
+          echo "GH_TOKEN=${{ inputs.token }}" >> $GITHUB_ENV
+        fi
+
+    - name: Comment on PR ${{ inputs.pr }}
+      shell: bash
+      id: comment
+      env:
+        BODY: |
+          ${{ inputs.comment }}
+      run: |
+        if [[ ${{ inputs.edit-last }} == "true" ]]; then
+          echo "link=$(gh pr comment ${{ env.PR }} --edit-last --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+        else
+          echo "link=$(gh pr comment ${{ env.PR }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+        fi

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Custom GitHub Actions for use across the ACCESS-NRI.
 * `docker-build-push`: Builds and pushes a docker image: [docker-build-push README.md](.github/actions/docker-build-push/README.md).
 * `bump-version`: Bumps a version string given a versioning scheme: [bump-version README.md](.github/actions/bump-version/README.md).
 * `react-to-comment`: Lets `github-actions[bot]` react to a comment. Usually useful to let users know there is some action in progress: [react-to-comment](.github/actions/react-to-comment/README.md).
+* `pr-comment`: Convenience action for letting `github-actions[bot]` comment on a given PR: [pr-comment](.github/actions/pr-comment/README.md).
 
 ## Workflows
 


### PR DESCRIPTION
Added a convenience action for `github-actions[bot]` to comment on a given PR. Is essentially a wrapper around a `action/checkout` call, then a `gh pr checkout` then a `gh pr comment`. 

References ACCESS-NRI/ACCESS-OM3#2