### PR TITLE
Added `validate-yaml` action

### DIFF
--- a/.github/actions/validate-yaml/README.md
+++ b/.github/actions/validate-yaml/README.md
@@ -1,0 +1,36 @@
+# Validate YAML Action
+
+This action validates a `.yaml` file given a `.json` spec, using `ajv`.
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `schema-location` | `string` | Path on the runner to the schema to use for validation | `true` | N/A | `'./path/to/schema.json'`, `'/opt/schema.json'` |
+| `yaml-location` | `string` | Path on the runner to the .yaml file to be validated | `true` | N/A | `'../my.yaml'`, `'/opt/some.yaml'` |
+| `strict-schema-validation` | `string` | Whether to validate the schema itself along with the yaml | `false` | `false` | `true`, `false` or `log` |
+| `schema-spec` | `string` | JSON schema specification to use, to be passed to `ajv` | `false` | `'draft07'` | `'draft2012-09'` (for others, see `ajv` documentation) |
+
+## Outputs
+
+This action has no outputs. The success of failure of the action denotes the success or failure of `ajv` to validate the data given the spec.
+
+## Examples
+
+```yaml
+# ...
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: valid
+        uses: access-nri/actions/.github/actions/validate-yaml@main
+        with:
+          yaml-location: ./config/my.yaml
+          schema-location: ./schema/my.schema.json
+
+      - if: always()
+        run: echo "::notice::The validation result was ${{ steps.valid.outcome }}!"
+```

--- a/.github/actions/validate-yaml/action.yml
+++ b/.github/actions/validate-yaml/action.yml
@@ -1,0 +1,40 @@
+name: Validate yaml
+description: Action that validates a given `.yaml` file against a given `.json` schema
+inputs:
+  schema-location:
+    type: string
+    required: true
+    description: Path on the runner to the schema to use for validation
+  yaml-location:
+    type: string
+    required: true
+    description: Path on the runner to the .yaml file to be validated
+  strict-schema-validation:
+    type: string
+    required: false
+    default: false
+    description: |
+      Whether to validate the schema itself along with the yaml.
+      Options are 'true', 'false' and 'log'
+  schema-spec:
+    type: string
+    required: false
+    default: draft7
+    description: JSON schema specification to use, to be passed to `ajv`
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - shell: bash
+      run: npm install -g ajv-cli@5.0.0
+
+    - shell: bash
+      run: |
+        ajv \
+          --spec=${{ inputs.schema-spec }} \
+          --strict=${{ inputs.strict-schema-validation }} \
+          -s ${{ inputs.schema-location }} \
+          -d ${{ inputs.yaml-location }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Custom GitHub Actions for use across the ACCESS-NRI.
 * `bump-version`: Bumps a version string given a versioning scheme: [bump-version README.md](.github/actions/bump-version/README.md).
 * `react-to-comment`: Lets `github-actions[bot]` react to a comment. Usually useful to let users know there is some action in progress: [react-to-comment](.github/actions/react-to-comment/README.md).
 * `pr-comment`: Convenience action for letting `github-actions[bot]` comment on a given PR: [pr-comment](.github/actions/pr-comment/README.md).
+* `validate-yaml`: Validate a given `.yaml` file against a `.json` spec: [validate-yaml](.github/actions/validate-yaml/README.md).
 
 ## Workflows
 


### PR DESCRIPTION
Added a new action for the validation of a `.yml` file using a `.json` schema, with `ajv`. Will be used to further the issue in ACCESS-NRI/build-cd#55