### PR TITLE
`docker-build-push`: Version Bump and Push Failure Fix

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -44,14 +44,14 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Buildx is currently required to use a subdirectory w/ build-push-action
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3.4.0
 
     - name: Log in to container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v2.3.0
       with:
         registry: ${{ inputs.container-registry }}
         username: ${{ github.repository_owner }}
@@ -59,14 +59,14 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5.5.1
       with:
         images: ${{ inputs.container-registry }}/${{ inputs.image-name }}
         flavor: |
           latest=true
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6.3.0
       with:
         context: "{{defaultContext}}:${{ inputs.dockerfile-directory }}"
         build-args: ${{ inputs.build-args }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -51,7 +51,7 @@ runs:
       uses: docker/setup-buildx-action@v3.4.0
 
     - name: Log in to container registry
-      uses: docker/login-action@v2.3.0
+      uses: docker/login-action@v3.2.0
       with:
         registry: ${{ inputs.container-registry }}
         username: ${{ github.repository_owner }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -56,6 +56,7 @@ runs:
         registry: ${{ inputs.container-registry }}
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
+        logout: false
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
@@ -74,8 +75,8 @@ runs:
         file: ${{ inputs.dockerfile-name }}
         push: ${{ inputs.push }}
         target: ${{ inputs.target }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ inputs.image-name }}:latest
+        labels: ${{ steps.meta.ouputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This update to the `docker-build-push` action brings some much needed version bumps, and some fixes to address the intermittent failures of the setting of metadata and tags on `build-ci` images, like so: https://github.com/ACCESS-NRI/build-ci/actions/runs/9835686632/job/27149836704

References ACCESS-NRI/build-ci#170