### PR TITLE
Add `commenter-permissions` action and README.md entry

### DIFF
--- a/.github/actions/commenter-permission-check/README.md
+++ b/.github/actions/commenter-permission-check/README.md
@@ -1,0 +1,49 @@
+# PR Commenter Permissions Check Action
+
+Action that determines whether a commenter on a PR has certain permissions on the repository
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `minimum-permission` | `string` | Minimum level of permission required on the given repository. One of: `none` `read` `write` `admin` | `true` | N/A | `admin` |
+| `exit-if-permission-denied` | `boolean` | Exit when commenter permission is denied | `true` | `false` | `true` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `has-permission` | `string` | If the commenter has at least the required permission level | `true` |
+
+## Examples
+
+### Simple
+
+```yaml
+# ...
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+    - id: commenter
+      uses: access-nri/actions/.github/actions/commenter-permission-check@main
+      with:
+        minimum-permission: write
+
+    - if: steps.commenter.outputs.has-permission == 'true'
+      run: echo "${{ github.event.comment.user.login }} has permission to do this step"
+```
+
+### More Complex
+
+```yaml
+# ...
+jobs:
+  commenter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: access-nri/actions/.github/actions/commenter-permission-check@main
+      with:
+        minimum-permission: admin
+        exit-if-permission-denied: true
+```

--- a/.github/actions/commenter-permission-check/action.yml
+++ b/.github/actions/commenter-permission-check/action.yml
@@ -15,7 +15,8 @@ inputs:
 outputs:
   has-permission:
     value: ${{ steps.commenter.outputs.permission }}
-    description: 'true' if the commenter has at least the required permission level, 'false' otherwise
+    description: |-
+      'true' if the commenter has at least the required permission level, 'false' otherwise
 runs:
   using: composite
   steps:

--- a/.github/actions/commenter-permission-check/action.yml
+++ b/.github/actions/commenter-permission-check/action.yml
@@ -1,0 +1,84 @@
+name: Commenter Permission Check
+description: Action that determines whether a commenter on a PR has certain permissions on the repository
+inputs:
+  minimum-permission:
+    type: string
+    required: true
+    description: |
+      Minimum level of permission required on the given repository.
+      One of: none read write admin.
+  exit-if-permission-denied:
+    type: boolean
+    required: true
+    default: false
+    description: Exit when commenter permission is denied.
+outputs:
+  has-permission:
+    value: ${{ steps.commenter.outputs.permission }}
+    description: 'true' if the commenter has at least the required permission level, 'false' otherwise
+runs:
+  using: composite
+  steps:
+    - name: Set required environment variables
+      shell: bash
+      run: echo "POSSIBLE_COMMENTER_PERMISSIONS=none read write admin" >> $GITHUB_ENV
+
+    - name: Check required context/variables exists
+      shell: bash
+      run: |
+        if ! grep --quiet "${{ inputs.minimum-permission }}" <<< "${{ env.POSSIBLE_COMMENTER_PERMISSIONS }}"; then
+          echo "::error::'${{ inputs.minimum-permission }}' is not one of '${{ env.POSSIBLE_COMMENTER_PERMISSIONS }}'"
+          exit 1
+        fi
+
+        if [[ -z "${{ github.event.issue.pull_request }}" ]]; then
+          echo "::error::This action requires an 'on.issue_comment' trigger, where the comment was on a Pull Request"
+          exit 1
+        fi
+
+        if [[ -z "${{ github.event.comment.user.login }}" ]]; then
+          echo "::error::Couldn't infer commenter login from context"
+          exit 1
+        fi
+
+    - name: Get list of sufficient permissions
+      id: sufficient-permissions
+      shell: bash
+      run: |
+        sufficient_permissions=""
+        sufficient_permission_found="false"
+
+        for permission in ${{ env.POSSIBLE_COMMENTER_PERMISSIONS }}; do
+          if [[ "${{ inputs.minimum-permission }}" == "$permission" || "$sufficient_permission_found" == "true" ]]; then
+            sufficient_permissions+="$permission "
+            sufficient_permission_found="true"
+          fi
+        done
+
+        echo "sufficient permissions are '$sufficient_permissions'"
+
+        echo "list=$sufficient_permissions" >> $GITHUB_OUTPUT
+
+    - name: Determine if commenter has permission to run the command
+      id: commenter
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        commenter_permissions=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission \
+          --jq '.permission'
+        )
+        if grep --quiet "$commenter_permissions" <<< "${{ steps.sufficient-permissions.outputs.list }}"; then
+          echo "Commenter has at least ${{ inputs.minimum-permission }} permission"
+          echo "permission=true" >> $GITHUB_OUTPUT
+        else
+          echo "Commenter does not have at least ${{ inputs.minimum-permission }} permission"
+          echo "permission=false" >> $GITHUB_OUTPUT
+          if [[ "${{ inputs.exit-if-permission-denied }}" == "true" ]]; then
+            echo "::error::Commenter does not have at least '${{ inputs.minimum-permission }}'"
+            exit 1
+          fi
+        fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Custom GitHub Actions for use across the ACCESS-NRI.
 * `bump-version`: Bumps a version string given a versioning scheme: [bump-version README.md](.github/actions/bump-version/README.md).
 * `react-to-comment`: Lets `github-actions[bot]` react to a comment. Usually useful to let users know there is some action in progress: [react-to-comment](.github/actions/react-to-comment/README.md).
 * `pr-comment`: Convenience action for letting `github-actions[bot]` comment on a given PR: [pr-comment](.github/actions/pr-comment/README.md).
+* `commenter-permissions-check`: Determine whether a commenter on a PR has write permissions on the repository: [commenter-permissions README.md](.github/actions/commenter-permission-check/README.md)
 
 ## Workflows
 


### PR DESCRIPTION
## Background

In this PR:
* Create an action that tests whether a user has sufficent permissions based on a comment written in a PR, based on https://github.com/ACCESS-NRI/model-config-tests/blob/8d7b5db6ec6d4c1b36902831a606402fa1328c73/.github/workflows/config-comment-test.yml#L23-L37

## Testing

Mostly done in https://github.com/codegat-test-org/test/pull/24 - see example of a user with permissions [comment](https://github.com/codegat-test-org/test/pull/24#issuecomment-2521723431) and the [workflow run](https://github.com/codegat-test-org/test/actions/runs/12189950253/job/34006095718#step:2:73). Alternatively, see a user without write permissions [comment](https://github.com/codegat-test-org/test/pull/24#issuecomment-2521683757) and the [workflow run](https://github.com/codegat-test-org/test/actions/runs/12189635900/job/34005187194#step:2:72)

All api calls were done locally for verification purposes. 

Closes #17
