### PR TITLE
`pr-comment`: Allow comment files

### DIFF
--- a/.github/actions/pr-comment/README.md
+++ b/.github/actions/pr-comment/README.md
@@ -9,15 +9,11 @@ This action comments on a given PR as `github-actions[bot]`.
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
-| `comment` | `string` | The body of the comment, in GitHub Markdown format | `true` | N/A | `"Hello this is a comment from PR 20"` |
+| `comment` | `string` | The body of the comment, in GitHub Markdown format. Can't be used with `comment-file` | `false` | N/A | `"Hello this is a comment from PR 20"` |
+| `comment-file` | `string` | Path to a file containing a comment, in GitHub Markdown format. Can't be used with `comment` | `false` | N/A | `"./comment.md"` |
 | `pr` | `number` | The Pull Request Number that will be commented on | `false` | `github.event.[pull_request\|issue].number` | `20` |
 | `edit-last` | `boolean` | Edit the last comment by `github-actions[bot]` instead of creating a new one | `false` | `false` | `true` |
 | `token` | `string` | A GitHub Token/PAT that allows commenting on the given PR | `false` | `github.token` | `gha_pat_abcds...` |
-
-outputs:
-  comment-link:
-    description:
-    value: ${{ steps.comment.outputs.link }}
 
 ## Outputs
 

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -76,5 +76,5 @@ runs:
         if [[ -n "${{ inputs.comment }}" ]]; then
           echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body-file '${{ inputs.comment-file }}')" >> $GITHUB_OUTPUT
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}")" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -3,8 +3,12 @@ description: Action that comments on a given PR
 inputs:
   comment:
     type: string
-    required: true
+    required: false
     description: The body of the comment, in GitHub Markdown format
+  comment-file:
+    type: string
+    required: false
+    description: Path to a file containing a comment, in GitHub Markdown format
   pr:
     type: number
     required: false
@@ -32,6 +36,15 @@ runs:
     - name: Set Non-Required Inputs
       shell: bash
       run: |
+        # Verify comment/file exists
+        if [[ -z "${{ inputs.comment }}" && -z "${{ inputs.comment-file }}" ]]; then
+          echo "::error::Neither comment nor comment-file are set"
+          exit 1
+        elif [[ -n "${{ inputs.comment }}" && -n "${{ inputs.comment-file }}" ]]; then
+          echo ":error::Both comment and comment-file are set"
+          exit 1
+        fi
+
         # Set PR
         if [[ -z "${{ inputs.pr }}" ]]; then
           if [[ -n "${{ github.event.issue }}" ]]; then
@@ -60,8 +73,8 @@ runs:
         BODY: |
           ${{ inputs.comment }}
       run: |
-        if [[ ${{ inputs.edit-last }} == "true" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} --edit-last --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
-        else
-          echo "link=$(gh pr comment ${{ env.PR }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+        if [[ -n "${{ inputs.comment }}" ]]; then
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+        elif [[ -n "${{ inputs.comment-file }}" ]]; then
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' }} --body-file '${{ inputs.comment-file }}')" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -74,7 +74,7 @@ runs:
           ${{ inputs.comment }}
       run: |
         if [[ -n "${{ inputs.comment }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' }} --body-file '${{ inputs.comment-file }}')" >> $GITHUB_OUTPUT
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body-file '${{ inputs.comment-file }}')" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -29,10 +29,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
     - name: Set Non-Required Inputs
       shell: bash
       run: |
@@ -74,7 +70,7 @@ runs:
           ${{ inputs.comment }}
       run: |
         if [[ -n "${{ inputs.comment }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body '${{ env.BODY }}')" >> $GITHUB_OUTPUT
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body '${{ env.BODY }}' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}")" >> $GITHUB_OUTPUT
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}" --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
Allow `gh pr comment --body-file` functionality in `pr-comment` while we move towards the `comment` action. 

In this PR:
- **pr-comment: Update to allow comment from file**

