### PR TITLE
Fix syntax error

### DIFF
--- a/.github/actions/comment/action.yml
+++ b/.github/actions/comment/action.yml
@@ -100,11 +100,11 @@ runs:
         fi
 
         # Set NUMBER
-        if [[ ${{ inputs.number }} != 0 && -n "${{ inputs.url }}" ]]; then # If both number and url are provided
+        if [[ -n "${{ inputs.number }}" && -n "${{ inputs.url }}" ]]; then # If both number and url are provided
           echo "::error::Cannot use 'number' and 'url' together. Please provide only one of them."
           exit 1
         fi
-        if [[ ${{ inputs.number }} == 0 ]]; then # If number is not provided (number type defaults to 0 -- https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs)
+        if [[ -z "${{ inputs.number }}" ]]; then # If number is not provided
           if [[ -n "$NUMBER" ]]; then # If url is provided
             echo "NUMBER=$NUMBER" >> $GITHUB_ENV
           elif [[ -n "${{ github.event.issue }}" ]]; then # If in an issue event
@@ -132,7 +132,7 @@ runs:
 
         # Set LABEL_STRING
         label=${{ inputs.label }}
-        echo "LABEL_STRING=<!-- pr-comment-action @@@${label}@@@ -->" >> $GITHUB_ENV
+        echo "LABEL_STRING=<!-- comment-action @@@${label}@@@ -->" >> $GITHUB_ENV
         
         # Set GH_TOKEN
         token="${{ inputs.token }}"


### PR DESCRIPTION
There is currently a [sintax error](https://github.com/ACCESS-NRI/access-hive.org.au/actions/runs/13128834958/job/36630070267?pr=876#step:5:294) in the `comment` action, caused by the misinterpretation of action inputs.

Line 107 performs a check for `${{ inputs.number }}`, thinking if it was not provided, it would have been set to 0 (as also referenced through the [link](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs)).
https://github.com/ACCESS-NRI/actions/blob/5c2f08f3bd7904f0e8e29ac591ba7b36ad5636f7/.github/actions/comment/action.yml#L107
However, I misinterpreted the documentation, and the link is valid only for inputs used within a GitHub workflow, not action!

I couldn't find any reference to `types` for [GitHub actions inputs](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs). 

In fact, the action inputs not provided are simply null and the context `${{ inputs.<input_not_provided> }}` would be substituted with nothing. This caused the error above.

This PR fixes it.

- [x] Fixed issue with 'default' value for inputs. 
- [x] Minor change to label text


> [!NOTE]
> I actually think the `type` keyword within GitHub actions inputs is not parsed at all by GitHub and is therefore not really needed (it could be deleted). However, it might still be useful to better explain the purpose of the inputs so I didn't delete it.



