### PR TITLE
`bump-version`: Update `calver-minor` from `MINOR` to double-padded `00MINOR`

### DIFF
--- a/.github/actions/bump-version/README.md
+++ b/.github/actions/bump-version/README.md
@@ -16,16 +16,16 @@ We currently support these versioning schemes. See the expanded section on Bumps
 
 | Scheme | Example | Available Bumps | Description |
 | ------ | ------- | --------------- | ----------- |
-| `calver-minor` | `YYYY.0M.MINOR` | `major`, `minor`, `current` | A variation of [Calender Versioning](https://calver.org/) where the Day field is instead a `MINOR` version number |
+| `calver-minor` | `YYYY.0M.00MINOR` | `major`, `minor`, `current` | A variation of [Calender Versioning](https://calver.org/) where the Day field is instead a double-padded `MINOR` version number |
 | `semver-major-minor` | `MAJOR.MINOR` | `major`, `minor` | A variation of [Semantic Versioning](https://semver.org/) which only deals with `MAJOR` and `MINOR` versions |
 
 #### `calver-minor` Bumps
 
 | Bump | Effect | Example |
 | ---- | ------ | ------- |
-| `major` | `YYYY.0M.MINOR` -> `YYYY.(0M+1).0` | `2024.02.3` -> `2024.03.0`, `2024.12.0` -> `2025.01.0` |
-| `minor` | `YYYY.0M.MINOR` -> `YYYY.0M.(MINOR+1)` | `2024.01.9` -> `2024.01.10` |
-| `current` | `YYYY.0M.MINOR` -> `(CURRENT_YEAR).(CURRENT_MONTH).0` | `2020.04.1` -> `2024.01.0` (the current date) |
+| `major` | `YYYY.0M.00MINOR` -> `YYYY.(0M+1).000` | `2024.02.003` -> `2024.03.000`, `2024.12.000` -> `2025.01.000` |
+| `minor` | `YYYY.0M.00MINOR` -> `YYYY.0M.00(MINOR+1)` | `2024.01.009` -> `2024.01.010` |
+| `current` | `YYYY.0M.00MINOR` -> `(CURRENT_YEAR).(CURRENT_MONTH).000` | `2020.04.001` -> `2024.01.000` (the current date) |
 
 #### `semver-major-minor` Bumps
 
@@ -38,8 +38,8 @@ We currently support these versioning schemes. See the expanded section on Bumps
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| `before` | `string` | Version before being bumped | `"2023.02.1"` |
-| `after` | `string` | Version after being bumped | `"2023.02.2"` |
+| `before` | `string` | Version before being bumped | `"2023.02.001"` |
+| `after` | `string` | Version after being bumped | `"2023.02.002"` |
 | `type` | `string` | Type of bump | `"minor"` |
 
 ## Usage
@@ -53,11 +53,11 @@ jobs:
       - id: cal-bump
         uses: access-nri/actions/.github/actions/bump-version@main
         with:
-          version: 2023.12.1
+          version: 2023.12.001
           versioning-scheme: calver-minor
           bump-type: minor
 
-      - run: echo "After doing a ${{ steps.cal-bump.outputs.type }} bump on version ${{ steps.cal-bump.outputs.before }}, we now have version ${{ steps.cal-bump.outputs.after}}!"  # After doing a minor bump on version 2023.12.1, we now have version 2023.12.2!
+      - run: echo "After doing a ${{ steps.cal-bump.outputs.type }} bump on version ${{ steps.cal-bump.outputs.before }}, we now have version ${{ steps.cal-bump.outputs.after}}!"  # After doing a minor bump on version 2023.12.001, we now have version 2023.12.002!
 
       - id: semver-bump
         uses: access-nri/actions/.github/actions/bump-version@main

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -4,18 +4,15 @@ description: Action for bumping a version string
 inputs:
   version:
     required: true
-    type: string
     description: The version string that will be bumped
   versioning-scheme:
     required: true
-    type: string
     description: |
       The type of versioning scheme used. Currently supports 'calver-minor', 'semver-major-minor', where:
-      'calver-minor': 'YYYY.OM.MINOR'.
+      'calver-minor': 'YYYY.0M.00MINOR'.
       'semver-major-minor': 'MAJOR.MINOR'.
   bump-type:
     required: true
-    type: string
     description: |
       The type of bump. This changes depending on the `versioning-scheme`.
       'calver-minor': 'major', 'minor' or 'current'.
@@ -85,7 +82,7 @@ runs:
       # Regarding the regex in the script: `([0-9]{4}\.(0[1-9]|1[1-2]))\.([0-9]+)` is broken down into:
       # `([0-9]{4}\.(0[1-9]|1[1-2]))`: Major version as a date in the form YYYY.0M (eg. `2024.03`)
       # `\.`: Version separator (eg. `.`)
-      # `([0-9]+)`: Minor version (eg. `1`)
+      # `([0-9]+)`: Minor version (eg. `001`)
       # which would give `2024.03.1`
       run: |
         regex="([0-9]{4}\.(0[1-9]|1[1-2]))\.([0-9]+)"
@@ -101,12 +98,14 @@ runs:
           # we convert '.' to `date`s expected '-'-separator for date formats, and add a day so it is a valid date
           major_version_valid_date="${major_version/./-}-01"
           major_version=$(date --date "${major_version_valid_date} + 1 month" +%Y.%m)
-          minor_version=0
+          minor_version=000
         elif [[ "${{ inputs.bump-type }}" == "minor" ]]; then
           minor_version=$((minor_version + 1))
+          # We pad the minor version with leading zeros to ensure it is 3 digits long
+          minor_version=$(printf "%03d" "${minor_version}")
         elif [[ "${{ inputs.bump-type }}" == "current" ]]; then
           major_version=$(date +%Y.%m)
-          minor_version=0
+          minor_version=000
         fi
 
         new_version="${major_version}.${minor_version}"


### PR DESCRIPTION
Closes ACCESS-NRI/build-cd#264

## Background

Guidance for `calver-minor` is that we need to double-pad our minor versions. See examples:

```
2025.01.0 -> 2025.01.000
2025.01.1 -> 2025.01.001
2025.01.10 -> 2025.01.010
2025.01.100 -> 2025.01.100
2025.01.1000 -> 2025.01.1000
```

We would also need to updated the versioning logic to account for this, which is what this PR does!

## The PR

* Double-pad the MINOR version in the `calver-minor` format. 
* Update documentation
* Remove `type: string` from action inputs - they aren't required because all inputs to actions are strings!

## Testing

* Validated `printf` padding works for values in the examples via `for n in 0 1 10 100 1000; do printf "2025.01.%d -> 2025.01.%03d\n" $n $n; done`
