### PR TITLE
pr-comment: Add single quotes to inputs.comment

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -31,12 +31,16 @@ runs:
   steps:
     - name: Set Non-Required Inputs
       shell: bash
+      env:
+        # Setting comment to an intermediate environment variable to handle
+        # special characters in the markdown formatted comments
+        COMMENT: ${{ inputs.comment }}
       run: |
         # Verify comment/file exists
-        if [[ -z '${{ inputs.comment }}' && -z "${{ inputs.comment-file }}" ]]; then
+        if [[ -z "${{ env.COMMENT }}" && -z "${{ inputs.comment-file }}" ]]; then
           echo "::error::Neither comment nor comment-file are set"
           exit 1
-        elif [[ -n '${{ inputs.comment }}' && -n "${{ inputs.comment-file }}" ]]; then
+        elif [[ -n "${{ env.COMMENT }}" && -n "${{ inputs.comment-file }}" ]]; then
           echo "::error::Both comment and comment-file are set"
           exit 1
         fi
@@ -66,11 +70,10 @@ runs:
       shell: bash
       id: comment
       env:
-        BODY: |
-          ${{ inputs.comment }}
+        COMMENT: ${{ inputs.comment }}
       run: |
-        if [[ -n '${{ inputs.comment }}' ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body '${{ env.BODY }}' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
+        if [[ -n "${{ env.COMMENT }}" ]]; then
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body '${{ env.COMMENT }}' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
           echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}" --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -37,10 +37,10 @@ runs:
         COMMENT: ${{ inputs.comment }}
       run: |
         # Verify comment/file exists
-        if [[ -z "${{ env.COMMENT }}" && -z "${{ inputs.comment-file }}" ]]; then
+        if [[ -z "${COMMENT}" && -z "${{ inputs.comment-file }}" ]]; then
           echo "::error::Neither comment nor comment-file are set"
           exit 1
-        elif [[ -n "${{ env.COMMENT }}" && -n "${{ inputs.comment-file }}" ]]; then
+        elif [[ -n "${COMMENT}" && -n "${{ inputs.comment-file }}" ]]; then
           echo "::error::Both comment and comment-file are set"
           exit 1
         fi
@@ -72,8 +72,8 @@ runs:
       env:
         COMMENT: ${{ inputs.comment }}
       run: |
-        if [[ -n "${{ env.COMMENT }}" ]]; then
-          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body '${{ env.COMMENT }}' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
+        if [[ -n "${COMMENT}" ]]; then
+          echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body "${COMMENT}" --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
           echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}" --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -33,11 +33,11 @@ runs:
       shell: bash
       run: |
         # Verify comment/file exists
-        if [[ -z "${{ inputs.comment }}" && -z "${{ inputs.comment-file }}" ]]; then
+        if [[ -z '${{ inputs.comment }}' && -z "${{ inputs.comment-file }}" ]]; then
           echo "::error::Neither comment nor comment-file are set"
           exit 1
-        elif [[ -n "${{ inputs.comment }}" && -n "${{ inputs.comment-file }}" ]]; then
-          echo ":error::Both comment and comment-file are set"
+        elif [[ -n '${{ inputs.comment }}' && -n "${{ inputs.comment-file }}" ]]; then
+          echo "::error::Both comment and comment-file are set"
           exit 1
         fi
 
@@ -69,7 +69,7 @@ runs:
         BODY: |
           ${{ inputs.comment }}
       run: |
-        if [[ -n "${{ inputs.comment }}" ]]; then
+        if [[ -n '${{ inputs.comment }}' ]]; then
           echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body '${{ env.BODY }}' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
         elif [[ -n "${{ inputs.comment-file }}" ]]; then
           echo "link=$(gh pr comment ${{ env.PR }} ${{ inputs.edit-last == 'true' && '--edit-last' || '' }} --body-file "${{ inputs.comment-file }}" --repo ${{ github.repository }})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR wraps `inputs.comment` in single quotes to avoid running text within backticks in the markdown formatted string.

Closes #26