### PR TITLE
Added the cache-svn-auth action

### DIFF
--- a/.github/actions/cache-svn-auth/README.md
+++ b/.github/actions/cache-svn-auth/README.md
@@ -2,6 +2,10 @@
 
 This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](https://svnbook.red-bean.com/en/1.7/svn-book.pdf) authentication password, for a specific svn realm.<br>
 
+> [! IMPORTANT ]
+> GitHub Runners are ephemeral, so SVN credential caching only persists within the same job. To ensure SVN access works as expected, this action must be executed in a step within the same job where subsequent SVN commands are run.
+> If SVN access is required across multiple jobs, you’ll need to invoke this action separately in each of those jobs.
+
 ## Inputs
 
 | Name | Type | Description | Required | Example |
@@ -22,21 +26,28 @@ This action is useful to cache SVN credentials with GPG, so svn commands can be 
 ## Examples
 
 <details>
-<summary><b>Cache SVN credentials for further steps</b></summary>
+<summary><b>Cache SVN credentials for the MetOffice SVN repo</b></summary>
 
 ```yaml
 # ...
-on: pull-request
 jobs:
-  comment:
+# ...
+  cache-svn-auth:
+    name: Cache SVN Authentication for MetOffice Repo
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-    - uses: access-nri/actions/.github/actions/comment@main
-      with:
-        message: |
-          Wow, a comment on PR `${{ github.event.pull_request.number }}`!
-          With multilines!
+      - name: Cache SVN authentication
+        uses: access-nri/actions/.github/actions/cache-svn-auth@main
+        with: 
+          username: '${{ secrets.MOSRS_USERNAME }}'
+          password: '${{ secrets.MOSRS_PASSWORD }}'
+          realm: '<https://code.metoffice.gov.uk:443> Met Office Code'
+    
+      - name: Run svn command
+        run: |
+          svn info --non-interactive https://code.metoffice.gov.uk/svn/utils/shumlib/trunk/
 ```
+
+> [!INFO]
+> For the workflow above to work, you need to set the `MOSRS_USERNAME` and `MOSRS_PASSWORDS` [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) in the repository that uses the workflow.
 </details>

--- a/.github/actions/cache-svn-auth/README.md
+++ b/.github/actions/cache-svn-auth/README.md
@@ -48,6 +48,7 @@ jobs:
           svn info --non-interactive https://code.metoffice.gov.uk/svn/utils/shumlib/trunk/
 ```
 
-> [!TIP]
-> For the workflow above to work, you need to set the `MOSRS_USERNAME` and `MOSRS_PASSWORDS` [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) in the repository that uses the workflow.
+:bulb:**TIP**<br>
+For the workflow above to work, you need to set the `MOSRS_USERNAME` and `MOSRS_PASSWORDS` [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) in the repository that uses the workflow.
+
 </details>

--- a/.github/actions/cache-svn-auth/README.md
+++ b/.github/actions/cache-svn-auth/README.md
@@ -1,8 +1,8 @@
 # SVN Authentication Caching Action
 
-This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](https://svnbook.red-bean.com/en/1.7/svn-book.pdf) authentication password, for a specific svn realm.<br>
+This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](https://svnbook.red-bean.com/en/1.7/svn-book.pdf)'s authentication password, for a specific SVN realm.<br>
 
-> [! IMPORTANT ]
+> [!IMPORTANT]
 > GitHub Runners are ephemeral, so SVN credential caching only persists within the same job. To ensure SVN access works as expected, this action must be executed in a step within the same job where subsequent SVN commands are run.
 > If SVN access is required across multiple jobs, you’ll need to invoke this action separately in each of those jobs.
 
@@ -12,16 +12,16 @@ This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](http
 | ---- | ---- | ----------- | -------- | ------- |
 | `username` | `string` | The SVN username. | YES | `myuser` |
 | `password` | `string` | The SVN password. | YES | `mypassword` |
-| `realm` | `string` | The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`.<br>To find the correct realm for your svn repo, you can read the `Authentication realm:` field when being prompted for authentication after running a command like `svn info https://your.svn.server.com/path/to/repo`. | YES | `<https://awesome.svn.repo.com:443> My awesome SVN repo` |
+| `realm` | `string` | The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`.<br>To find the correct realm for your SVN repo, you can read the `Authentication realm:` field when being prompted for authentication after running a command like `svn info https://your.svn.server.com/path/to/repo`. | YES | `<https://awesome.svn.repo.com:443> My awesome SVN repo` |
 
 ## Outputs
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| `svn-cache-id` | `string` | The svn cache-id used for the authentication. This is obtained by computing the md5 hash of the svn `realm` input. | `2be6a67d04b1c8c6d879daafa52fd762` |
+| `svn-cache-id` | `string` | The SVN cache-id used for the authentication. This is obtained by computing the md5 hash of the SVN `realm` input. | `2be6a67d04b1c8c6d879daafa52fd762` |
 
 ## Usage 
-This action is useful to cache SVN credentials with GPG, so svn commands can be issued in `--non-interactive` mode without needing manual authentication.
+This action is useful to cache SVN credentials with GPG, so SVN commands can be issued in `--non-interactive` mode without needing manual authentication.
 
 ## Examples
 
@@ -48,6 +48,6 @@ jobs:
           svn info --non-interactive https://code.metoffice.gov.uk/svn/utils/shumlib/trunk/
 ```
 
-> [!INFO]
+> [!TIP]
 > For the workflow above to work, you need to set the `MOSRS_USERNAME` and `MOSRS_PASSWORDS` [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) in the repository that uses the workflow.
 </details>

--- a/.github/actions/cache-svn-auth/README.md
+++ b/.github/actions/cache-svn-auth/README.md
@@ -1,0 +1,42 @@
+# SVN Authentication Caching Action
+
+This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](https://svnbook.red-bean.com/en/1.7/svn-book.pdf) authentication password, for a specific svn realm.<br>
+
+## Inputs
+
+| Name | Type | Description | Required | Example |
+| ---- | ---- | ----------- | -------- | ------- |
+| `username` | `string` | The SVN username. | YES | `myuser` |
+| `password` | `string` | The SVN password. | YES | `mypassword` |
+| `realm` | `string` | A svn realm string, often in the form `<https://svn.domain.com:443> Description of realm` | YES | `<https://awesome.svn.repo.com:443> My awesome SVN repo` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `svn-cache-id` | `string` | The svn cache-id used for the authentication. This is obtained by computing the md5 hash of the svn `realm` input. | `2be6a67d04b1c8c6d879daafa52fd762` |
+
+## Usage 
+This action is useful to cache SVN credentials with GPG, so svn commands can be issued in `--non-interactive` mode without needing manual authentication.
+
+## Examples
+
+<details>
+<summary><b>Cache SVN credentials for further steps</b></summary>
+
+```yaml
+# ...
+on: pull-request
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: access-nri/actions/.github/actions/comment@main
+      with:
+        message: |
+          Wow, a comment on PR `${{ github.event.pull_request.number }}`!
+          With multilines!
+```
+</details>

--- a/.github/actions/cache-svn-auth/README.md
+++ b/.github/actions/cache-svn-auth/README.md
@@ -8,7 +8,7 @@ This action uses GnuPG (GPG) passphrase caching to cache [Subversion (SVN)](http
 | ---- | ---- | ----------- | -------- | ------- |
 | `username` | `string` | The SVN username. | YES | `myuser` |
 | `password` | `string` | The SVN password. | YES | `mypassword` |
-| `realm` | `string` | A svn realm string, often in the form `<https://svn.domain.com:443> Description of realm` | YES | `<https://awesome.svn.repo.com:443> My awesome SVN repo` |
+| `realm` | `string` | The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`.<br>To find the correct realm for your svn repo, you can read the `Authentication realm:` field when being prompted for authentication after running a command like `svn info https://your.svn.server.com/path/to/repo`. | YES | `<https://awesome.svn.repo.com:443> My awesome SVN repo` |
 
 ## Outputs
 

--- a/.github/actions/cache-svn-auth/action.yml
+++ b/.github/actions/cache-svn-auth/action.yml
@@ -1,0 +1,108 @@
+name: Cache SVN Authentication
+description: Action that uses GPG to cache SVN authentication password and sets up a SVN auth cache
+inputs:
+  username:
+    type: string
+    required: true
+    description: The SVN username.
+  password:
+    type: string
+    required: true
+    description: The SVN password.
+  realm:
+    type: string
+    required: true
+    description: The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`.
+outputs:
+  svn-cache-id:
+    description: |
+      The svn cache-id used for the authentication. 
+      This is obtained by computing the md5 hash of the svn realm input.
+    value: ${{ steps.get-cache-id.outputs.svn-cache-id }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up SVN
+      shell: bash
+      run: |
+        # Check SVN is installed
+        if ! svn --version; then
+          echo "::error::SVN is not installed. Please install SVN before using this action."
+          exit 1
+        fi
+        # Set up SVN config
+        mkdir -p ~/.subversion
+        cat > ~/.subversion/servers <<EOF
+        [global]
+        store-passwords = yes
+        store-plaintext-passwords = no
+        EOF
+    
+    - name: Set up GPG-agent
+      shell: bash
+      run: |
+        # Check GPG is installed
+        if ! gpg --version; then
+          echo "::error::GPG is not installed. Please install GPG before using this action."
+          exit 1
+        fi
+        # Kill any existing GPG-agent processes
+        socket_dir=$(gpgconf --list-dirs socketdir)
+        rm -rf $socket_dir
+        # Start GPG-agent with preset passphrase support
+        eval $(gpg-agent --daemon --allow-preset-passphrase)
+        pid=$(gpg-connect-agent 'GETINFO pid' /bye | awk '{print $2}')
+        echo "GPG Agent PID: $pid"
+
+    - name: Get svn cache-id
+      id: get-cache-id
+      shell: bash
+      run: |
+        # Compute md5 hash of the realm input
+        cache_id=$(echo -n '${{ inputs.realm }}' | openssl md5 | awk '{print $2}')
+        echo "SVN cache id for '${{ inputs.realm }}': $cache_id"
+        echo "svn-cache-id=$cache_id" >> $GITHUB_OUTPUT
+    
+    - name: Cache SVN authentication
+      shell: bash
+      run: |
+        # Compute lengths of inputs, needed for svn auth cache file
+        realm='${{ inputs.realm }}'
+        username='${{ inputs.username }}'
+        len_realm=$(echo ${#realm})
+        len_username=$(echo ${#username})
+        # Add svn cache file
+        mkdir -p ~/.subversion/auth/svn.simple
+        cat > ~/.subversion/auth/svn.simple/${{ steps.get-cache-id.outputs.svn-cache-id }} <<EOF
+        K 8
+        passtype
+        V 9
+        gpg-agent
+        K 15
+        svn:realmstring
+        V $len_realm
+        $realm
+        K 8
+        username
+        V $len_username
+        $username
+        END
+        EOF
+    
+    - name: Cache SVN password in GPG-agent
+      shell: bash
+      run: |
+        # Encode password in hexadecimal format
+        psw='${{ inputs.password }}'
+        hex_psw=$(echo -n "$psw" | xxd -p)
+        echo "psw=$psw"
+        echo "hex_psw=$hex_psw"
+        # Set GPG passphrase caching
+        echo "Caching SVN password for realm '${{ inputs.realm }}'..."
+        cache_id='${{ steps.get-cache-id.outputs.svn-cache-id }}'
+        gpg-connect-agent "PRESET_PASSPHRASE $cache_id -1 $hex_psw" /bye
+        echo "SVN password cached successfully for realm '${{ inputs.realm }}'."

--- a/.github/actions/cache-svn-auth/action.yml
+++ b/.github/actions/cache-svn-auth/action.yml
@@ -12,7 +12,10 @@ inputs:
   realm:
     type: string
     required: true
-    description: The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`.
+    description: |
+      The SVN realm. Often in the form `<https://svn.domain.com:443> Description of realm`. 
+      To find the correct realm for your svn repo, you can read the 'Authentication realm:' field when being 
+      prompted for authentication after running a command like `svn info https://your.svn.server.com/path/to/repo`.
 outputs:
   svn-cache-id:
     description: |
@@ -22,6 +25,22 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up GPG-agent
+      shell: bash
+      run: |
+        # Check GPG is installed
+        if ! gpg --version; then
+          echo "::error::GPG is not installed. Please install GPG before using this action."
+          exit 1
+        fi
+        # Kill any existing GPG-agent processes
+        socket_dir=$(gpgconf --list-dirs socketdir)
+        rm -rf $socket_dir
+        # Start GPG-agent with preset passphrase support
+        eval $(gpg-agent --daemon --allow-preset-passphrase)
+        pid=$(gpg-connect-agent 'GETINFO pid' /bye | awk '{print $2}')
+        echo "GPG Agent PID: $pid"
+    
     - name: Set up SVN
       shell: bash
       run: |
@@ -40,22 +59,6 @@ runs:
         store-plaintext-passwords = no
         EOF
     
-    - name: Set up GPG-agent
-      shell: bash
-      run: |
-        # Check GPG is installed
-        if ! gpg --version; then
-          echo "::error::GPG is not installed. Please install GPG before using this action."
-          exit 1
-        fi
-        # Kill any existing GPG-agent processes
-        socket_dir=$(gpgconf --list-dirs socketdir)
-        rm -rf $socket_dir
-        # Start GPG-agent with preset passphrase support
-        eval $(gpg-agent --daemon --allow-preset-passphrase)
-        pid=$(gpg-connect-agent 'GETINFO pid' /bye | awk '{print $2}')
-        echo "GPG Agent PID: $pid"
-
     - name: Get svn cache-id
       id: get-cache-id
       shell: bash
@@ -71,8 +74,8 @@ runs:
         # Compute lengths of inputs, needed for svn auth cache file
         realm='${{ inputs.realm }}'
         username='${{ inputs.username }}'
-        len_realm=$(echo ${#realm})
-        len_username=$(echo ${#username})
+        len_realm=${#realm}
+        len_username=${#username}
         # Add svn cache file
         mkdir -p ~/.subversion/auth/svn.simple
         cat > ~/.subversion/auth/svn.simple/${{ steps.get-cache-id.outputs.svn-cache-id }} <<EOF
@@ -98,6 +101,5 @@ runs:
         hex_psw=$(echo -n '${{ inputs.password }}' | xxd -p)
         # Set GPG passphrase caching
         echo "Caching SVN password for realm '${{ inputs.realm }}'..."
-        cache_id='${{ steps.get-cache-id.outputs.svn-cache-id }}'
-        gpg-connect-agent "PRESET_PASSPHRASE $cache_id -1 $hex_psw" /bye
+        gpg-connect-agent "PRESET_PASSPHRASE ${{ steps.get-cache-id.outputs.svn-cache-id }} -1 $hex_psw" /bye
         echo "SVN password cached successfully for realm '${{ inputs.realm }}'."

--- a/.github/actions/cache-svn-auth/action.yml
+++ b/.github/actions/cache-svn-auth/action.yml
@@ -22,10 +22,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
     - name: Set up SVN
       shell: bash
       run: |

--- a/.github/actions/cache-svn-auth/action.yml
+++ b/.github/actions/cache-svn-auth/action.yml
@@ -29,10 +29,12 @@ runs:
     - name: Set up SVN
       shell: bash
       run: |
-        # Check SVN is installed
+        # Check SVN is installed, if not, install it
         if ! svn --version; then
-          echo "::error::SVN is not installed. Please install SVN before using this action."
-          exit 1
+          echo "SVN is not installed. Installing it..."
+          sudo apt-get update
+          sudo apt-get install -y subversion
+          svn --version
         fi
         # Set up SVN config
         mkdir -p ~/.subversion

--- a/.github/actions/cache-svn-auth/action.yml
+++ b/.github/actions/cache-svn-auth/action.yml
@@ -99,10 +99,7 @@ runs:
       shell: bash
       run: |
         # Encode password in hexadecimal format
-        psw='${{ inputs.password }}'
-        hex_psw=$(echo -n "$psw" | xxd -p)
-        echo "psw=$psw"
-        echo "hex_psw=$hex_psw"
+        hex_psw=$(echo -n '${{ inputs.password }}' | xxd -p)
         # Set GPG passphrase caching
         echo "Caching SVN password for realm '${{ inputs.realm }}'..."
         cache_id='${{ steps.get-cache-id.outputs.svn-cache-id }}'


### PR DESCRIPTION
## Overview

- [x] Added `cache-svn-auth` action, to cache SVN authentication using GPG agent
- [x] Added README for the action
- [x] Successfully tested [latest commit](https://github.com/ACCESS-NRI/actions/pull/29/commits/3416c8262beac914e556b7025cf369ccd16e328e) in [this workflow run](https://github.com/ACCESS-NRI-TEST/metomi_packages/actions/runs/16771826200)

This action is particularly useful for caching SVN credentials to connect to the MetOffice Science Repository (MOSRS), so that commands can be issued as `svn <command> --non-interactive` getting their authentication from the cached SVN auth and GPG-agent.
