### PR TITLE
Upload artifacts also when only one needed job is run

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -196,6 +196,7 @@ jobs:
     name: Upload artifact with tarball and built packages
     runs-on: ubuntu-latest
     needs: [publish-pypi-package, publish-conda-package]
+    if: ${{ success() && contains(needs.*.result, 'success') }}
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:


### PR DESCRIPTION
The fix makes sure the "Upload artifact" job runs also when one of the needed jobs is skipped in case the workflow is used with `pypi-package: false` or `conda-package: false`.