### PR TITLE
Fix upload-artifact job conditional

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -196,7 +196,9 @@ jobs:
     name: Upload artifact with tarball and built packages
     runs-on: ubuntu-latest
     needs: [publish-pypi-package, publish-conda-package]
-    if: ${{ success() && contains(needs.*.result, 'success') }}
+    # Run job if any needed job succeded, even if others are skipped or cancelled. 
+    # Don't run if any needed job failed or no jobs succeded (all skipped or cancelled).
+    if: ${{ ! contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:


### PR DESCRIPTION
Fix to the conditional for the `upload-artifact` job. 
The previous `success()` evaluates to `true` only if **all** needed previous jobs succeed, if any is skipped it will evaluate to `false`, which is not the logic we want.