### PR TITLE
Fix upload-artifact job not to be directly skipped if a needed job is skipped

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -198,7 +198,7 @@ jobs:
     needs: [publish-pypi-package, publish-conda-package]
     # Run job if any needed job succeded, even if others are skipped or cancelled. 
     # Don't run if any needed job failed or no jobs succeded (all skipped or cancelled).
-    if: ${{ ! contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
+    if: ${{ always() && ! contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:


### PR DESCRIPTION
Without `always()`, if any of the needed jobs is skipped the job will be directly skipped, without its `if` condition being evaluated.