### PR TITLE
Update setup ssh with passphrase

### DIFF
--- a/.github/actions/setup-ssh/README.md
+++ b/.github/actions/setup-ssh/README.md
@@ -3,7 +3,7 @@
 This action sets up `ssh` to use a given key, and adds to `~/.ssh/known_hosts`.
 
 > [!IMPORTANT]  
-> If the `private-key-passphrase` input is not provided, the SSH key (`private-key`) must have been created with no (empty) passphrase, otherwise SSH authentication will likely fail.
+> If the `private-key-passphrase` input is not provided, the SSH key (`private-key`) must have been created with no (empty) passphrase, otherwise SSH authentication will fail.
 
 ## Inputs
 

--- a/.github/actions/setup-ssh/README.md
+++ b/.github/actions/setup-ssh/README.md
@@ -2,6 +2,9 @@
 
 This action sets up `ssh` to use a given key, and adds to `~/.ssh/known_hosts`.
 
+> [!IMPORTANT]  
+> If the `private-key-passphrase` input is not provided, the SSH key (`private-key`) must have been created with no (empty) passphrase, otherwise SSH authentication will likely fail.
+
 ## Inputs
 
 | Name | Type | Description | Required | Default | Example |
@@ -9,6 +12,7 @@ This action sets up `ssh` to use a given key, and adds to `~/.ssh/known_hosts`.
 | hosts | string | Newline-separated list of hosts for ssh-keyscan lookup | false | N/A | 'localhost' |
 | private-key | string | Raw private key to add | true | N/A | '---- OPENSSH PRIVATE KEY ---- ...' |
 | private-key-name | string | Name of the ephemeral private key file to store in `~/.ssh` | false | 'priv.key' | 'key.pem' | 
+| private-key-passphrase | string | Passphrase of the private key. If a passphrase is not provided, the private-key must have been created with no (empty) passphrase for the `ssh` command not to fail | false | '' | 'mysecretpassphrase' |
 
 ## Outputs
 
@@ -27,7 +31,24 @@ steps:
       hosts: |
         host1.example.com
         host2.example.com
+      private-key: ${{ secrets.PRIVATE_KEY }} # Key with empty passphrase
+  - run: |
+      ssh user@host1.example.com -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+      echo "Hello from host1!"
+      EOT
+```
+
+```yaml
+# ...
+steps:
+  - id: ssh
+    uses: access-nri/actions/.github/actions/setup-ssh@main
+    with:
+      hosts: |
+        host1.example.com
+        host2.example.com
       private-key: ${{ secrets.PRIVATE_KEY }}
+      private-key-passphrase: ${{ secrets.PRIVATE_KEY_PASSPHRASE }}
   - run: |
       ssh user@host1.example.com -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
       echo "Hello from host1!"

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -11,6 +11,9 @@ inputs:
     required: false
     description: name of ephemeral generated private key file
     default: 'priv.key'
+  private-key-passphrase:
+    required: false
+    description: Passphrase for the private key
 outputs:
   private-key-path:
     value: ${{ steps.pk.outputs.path }}
@@ -33,6 +36,47 @@ runs:
         echo "$KEY" > ~/.ssh/$KEY_NAME
         chmod 600 ~/.ssh/$KEY_NAME
         echo "path=~/.ssh/$KEY_NAME" >> $GITHUB_OUTPUT
+    - name: Check passphrase
+      shell: bash
+      env:
+        PASSPHRASE: ${{ inputs.private-key-passphrase }}
+        KEY_PATH: ${{ steps.pk.outputs.path }}
+      run: |
+        # Try to decrypt the private key with the provided passphrase (if any)
+        if ! ssh-keygen -y -P "$PASSPHRASE" -f "$KEY_PATH" &> /dev/null; then
+          # If no passphrase is provided, warn that the private key might need one
+          if [[ -z "$PASSPHRASE" ]]; then
+            echo "::warning::The provided 'private-key' is passphrase-protected, but no 'private-key-passphrase' was provided. SSH commands may fail."
+          else
+            # If the passphrase is provided then it is incorrect. Fail with an error
+            echo "::error::The provided 'private-key-passphrase' is incorrect for the provided 'private-key'."
+            exit 1
+          fi
+        fi
+
+    # For security reasons, ssh-add doesn't allow to pass the passphrase from stdin,
+    # therefore we must use expect (https://gist.github.com/matthiasbalke/f0abe1e6c18704f086389009075c645e)
+    - name: Add passphrase to ssh-agent
+      if: inputs.private-key-passphrase != ''
+      shell: bash
+      env:
+        PASSPHRASE: ${{ inputs.private-key-passphrase }}
+        KEY_PATH: ${{ steps.pk.outputs.path }}
+      run: |
+        # Download and install expect
+        sudo apt-get install -y expect
+        # Start ssh-agent and add the private key with the passphrase
+        eval "$(ssh-agent -s)"
+        expect -c "
+          spawn ssh-add \"$KEY_PATH\"
+          expect \"Enter passphrase for *\"
+          send \"${PASSPHRASE}\n\"
+          expect \"Identity added: *\"
+        "
+        # Export SSH_AUTH_SOCK and SSH_AGENT_PID to the environment so subsequent steps
+        # in the job using this action can use the same ssh-agent
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+        echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
     - name: Add to known_hosts
       if: inputs.hosts != ''
       shell: bash

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -45,7 +45,8 @@ runs:
       run: |
         # Try to decrypt the private key with the provided passphrase (if any)
         if ! ssh-keygen -y -P "$PASSPHRASE" -f "$KEY_PATH" > /dev/null; then
-          # If no passphrase is provided, warn that the private key might need one
+          # If the decryption fail, it means that either the private key is passphrase-protected
+          # but no passphrase was provided, or the provided passphrase is incorrect
           if [[ -z "$PASSPHRASE" ]]; then
             msg="The provided 'private-key' is passphrase-protected, but no 'private-key-passphrase' was provided."
           else

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -33,27 +33,27 @@ runs:
         KEY: ${{ inputs.private-key }}
         KEY_NAME: ${{ inputs.private-key-name }}
       run: |
-        echo "$KEY" > ~/.ssh/$KEY_NAME
-        chmod 600 ~/.ssh/$KEY_NAME
-        echo "path=~/.ssh/$KEY_NAME" >> $GITHUB_OUTPUT
+        path="$HOME/.ssh/$KEY_NAME"
+        echo "$KEY" > "$path"
+        chmod 600 "$path"
+        echo "path=$path" >> $GITHUB_OUTPUT
     - name: Check passphrase
       shell: bash
       env:
-        PASSPHRASE: ${{ inputs.private-key-passphrase }}
-        KEY_PATH: ${{ steps.pk.outputs.path }}
+        PASSPHRASE: "${{ inputs.private-key-passphrase }}"
+        KEY_PATH: "${{ steps.pk.outputs.path }}"
       run: |
         # Try to decrypt the private key with the provided passphrase (if any)
-        if ! ssh-keygen -y -P "$PASSPHRASE" -f "$KEY_PATH" &> /dev/null; then
+        if ! ssh-keygen -y -P "$PASSPHRASE" -f "$KEY_PATH" > /dev/null; then
           # If no passphrase is provided, warn that the private key might need one
           if [[ -z "$PASSPHRASE" ]]; then
-            echo "::warning::The provided 'private-key' is passphrase-protected, but no 'private-key-passphrase' was provided. SSH commands may fail."
+            msg="The provided 'private-key' is passphrase-protected, but no 'private-key-passphrase' was provided."
           else
-            # If the passphrase is provided then it is incorrect. Fail with an error
-            echo "::error::The provided 'private-key-passphrase' is incorrect for the provided 'private-key'."
-            exit 1
+            msg="The provided 'private-key-passphrase' is incorrect for the provided 'private-key'."
           fi
+          echo "::error::$msg"
+          exit 1
         fi
-
     # For security reasons, ssh-add doesn't allow to pass the passphrase from stdin,
     # therefore we must use expect (https://gist.github.com/matthiasbalke/f0abe1e6c18704f086389009075c645e)
     - name: Add passphrase to ssh-agent
@@ -70,7 +70,7 @@ runs:
         expect -c "
           spawn ssh-add \"$KEY_PATH\"
           expect \"Enter passphrase for *\"
-          send \"${PASSPHRASE}\n\"
+          send \"${PASSPHRASE}\r\"
           expect \"Identity added: *\"
         "
         # Export SSH_AUTH_SOCK and SSH_AGENT_PID to the environment so subsequent steps

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -1,0 +1,171 @@
+# Workflow to test the setup-ssh action
+name: Test setup-ssh action
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/actions/setup-ssh/**'
+      - '.github/workflows/test-setup-ssh.yml'
+  push: 
+    branches:
+      - davide/update_setup_ssh
+
+env:
+    TESTED_ACTION: "setup-ssh"
+    PRIVATE_KEY: "/tmp/id_test"
+    PRIVATE_KEY_NO_PASSPHRASE: "/tmp/id_test_no_passphrase"
+
+jobs:
+  # Generate ephemeral SSH keys for testing
+  generate-ssh-keys:
+    name: Generate SSH keys
+    runs-on: ubuntu-latest
+    outputs:
+      private-key: ${{ steps.gen-keys.outputs.private-key }}
+      private-key-no-passphrase: ${{ steps.gen-keys.outputs.private-key-no-passphrase }}
+      public-key: ${{ steps.gen-keys.outputs.public-key }}
+      public-key-no-passphrase: ${{ steps.gen-keys.outputs.public-key-no-passphrase }}
+      passphrase: ${{ steps.set-passphrase.outputs.passphrase }}
+    steps:
+      # We need to set a passphrase as an output instead of an environment variable
+      # because environment variables are not supported in the matrix strategy
+      - name: Set passphrase
+        id: set-passphrase
+        run: echo "passphrase=passphrase" >> $GITHUB_OUTPUT
+
+      - name: Generate SSH key pair
+        id: gen-keys
+        run: |
+          # Generate an SSH key pair with passphrase
+          ssh-keygen -N "${{ steps.set-passphrase.outputs.passphrase }}" -f "${{ env.PRIVATE_KEY }}"
+          # Generate an SSH key pair with no passphrase
+          ssh-keygen -N "" -f "${{ env.PRIVATE_KEY_NO_PASSPHRASE }}"
+          # Use multiline GitHub output for private keys
+          # Passphrase-protected key
+          echo "private-key<<EOF" >> $GITHUB_OUTPUT
+          cat "${{ env.PRIVATE_KEY }}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "public-key=$(cat ${{ env.PRIVATE_KEY }}.pub)" >> $GITHUB_OUTPUT
+          # No-passphrase key
+          echo "private-key-no-passphrase<<EOF" >> $GITHUB_OUTPUT
+          cat "${{ env.PRIVATE_KEY_NO_PASSPHRASE }}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "public-key-no-passphrase=$(cat ${{ env.PRIVATE_KEY_NO_PASSPHRASE }}.pub)" >> $GITHUB_OUTPUT
+
+  # We cannot use jenseng/dynamic-uses to run the action because it doesn't handle multiline inputs (like the SSH key)
+  # so we need to change the matrix fields to contain all inputs
+  test-action:
+    name: Test ${{ matrix.id }} - ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    needs: generate-ssh-keys
+    env:
+      TEST_USERNAME: "test"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: 1
+            label: "Passphrase"
+            description: |
+              Test action with SSH key with passphrase.
+            input-hosts: ""
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
+            outcome: "success"
+          - id: 2
+            label: "No passphrase"
+            description: |
+              Test action with SSH key without passphrase.
+            input-hosts: ""
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: ""
+            outcome: "success"
+          - id: 3
+            label: "Failure - wrong passphrase provided"
+            description: |
+              Test action with wrong passphrase provided.
+            input-hosts: ""
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "wrong_passphrase"
+            outcome: "failure"
+          - id: 4
+            label: "Failure - no passphrase provided"
+            description: |
+              Test action with no passphrase provided when needed.
+            input-hosts: ""
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: ""
+            outcome: "failure"
+          - id: 5
+            label: "Passphrase provided when not needed"
+            description: |
+              Test action with passphrase provided when not needed.
+            input-hosts: ""
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
+            outcome: "success"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Description
+        run: echo "${{ matrix.description }}"
+      
+      # We spawn a test SSH server using the docker-openssh-server docker image 
+      # (https://github.com/linuxserver/docker-openssh-server) in detached mode
+      # We set the authorized keys by creating a directory containing the public SSH keys and
+      # using the PUBLIC_KEY_DIR env variable
+      - name: Spawn a test SSH server
+        run: |
+          # Create a directory for the authorized keys
+          authorized_keys_dir=$(mktemp -d)
+          cat > "$authorized_keys_dir/id_test.pub" <<< "${{ needs.generate-ssh-keys.outputs.public-key }}"
+          cat > "$authorized_keys_dir/id_test-no-passphrase.pub" <<< "${{ needs.generate-ssh-keys.outputs.public-key-no-passphrase }}"
+          docker run \
+            -d \
+            --name test-ssh-server \
+            -p 2222:2222 \
+            -v "$authorized_keys_dir:/pubkeys:ro" \
+            -e PUBLIC_KEY_DIR=/pubkeys \
+            -e USER_NAME=${{ env.TEST_USERNAME }} \
+            lscr.io/linuxserver/openssh-server:latest
+          sleep 2 # Wait for the SSH server to start
+
+      # We cannot use jenseng/dynamic-uses because it doesn't handle multiline inputs (like the SSH key)
+      - name: Run action
+        id: run-action
+        continue-on-error: true
+        uses: ./.github/actions/setup-ssh
+        with: 
+          hosts: "${{ matrix.input-hosts }}"
+          private-key: "${{ matrix.input-private-key }}"
+          private-key-name: "${{ matrix.input-private-key-name }}"
+          private-key-passphrase: "${{ matrix.input-private-key-passphrase }}"
+
+      - name: Verify failed action outcome
+        if: matrix.outcome == 'failure'
+        run: |
+          if [[ '${{ steps.run-action.outcome }}' == failure ]]; then
+            exit 0
+          fi
+          exit 1
+
+      - name: Verify SSH connection
+        if: matrix.outcome == 'success'
+        run: |
+          ssh -vvv \
+            -i '${{ steps.run-action.outputs.private-key-path }}' \
+            -p 2222 \
+            -o StrictHostKeyChecking=${{ matrix.input-hosts == '' && 'no' || 'yes' }} \
+            ${{ env.TEST_USERNAME }}@localhost \
+            exit 0
+
+      - name: Cleanup SSH server
+        if: always()
+        run: docker rm -f test-ssh-server 2>/dev/null || true

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -5,11 +5,8 @@ on:
     branches:
       - main
     paths:
-      - '.github/actions/setup-ssh/**'
+      - '.github/actions/setup-ssh/action.yml'
       - '.github/workflows/test-setup-ssh.yml'
-  push: 
-    branches:
-      - davide/update_setup_ssh
 
 env:
     TESTED_ACTION: "setup-ssh"
@@ -169,3 +166,31 @@ jobs:
       - name: Cleanup SSH server
         if: always()
         run: docker rm -f test-ssh-server 2>/dev/null || true
+    
+  # To test with the hosts input we need a real world scenario with a real SSH server, 
+  # so we cannot use the same ephemeral SSH keys generated for the previous job.
+  test-real-host:
+    name: Test real host with passphrase
+    runs-on: ubuntu-latest
+    environment: test-setup-ssh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run action
+        id: run-action
+        uses: ./.github/actions/setup-ssh
+        with: 
+          hosts: ${{ secrets.HOST }}
+          private-key: "${{ secrets.SSH_KEY }}"
+          private-key-passphrase: "${{ secrets.PASSPHRASE }}"
+      
+      # We try to connect with '-o StrictHostKeyChecking=yes' to verify that the SSH key is
+      # correctly added to the known_hosts
+      - name: Verify SSH connection
+        run: |
+          ssh -vvv \
+            -i '${{ steps.run-action.outputs.private-key-path }}' \
+            -o StrictHostKeyChecking=yes \
+            ${{ secrets.USER }}@${{ secrets.HOST }} \
+            exit 0


### PR DESCRIPTION
- [x] Updated setup-ssh action to allow passing a passphrase as an input.
- [x] Added tests for setup-ssh action
- [x] Updated README

The old functionality was kept unchanged, and the action still works in the same way if a passphrase-less SSH KEY is provided, and no passphrase input is specified.

Successful test (including a "real-world" test case) can be found in [this workflow run](https://github.com/ACCESS-NRI/actions/actions/runs/23120335795).