### PR TITLE
Fix README example for `validate-json.yml`

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ However, it does return job failure/success based on the result of the schema va
 ```yaml
 jobs:
   validate:
-    uses: access-nri/actions/.github/workflows/validate-json@main
+    uses: access-nri/actions/.github/workflows/validate-json.yml@main
     with:
       src: 'config'
 ```


### PR DESCRIPTION
MInor update in the README for a missing `.yml` in the usage example.