### PR TITLE
setup-ssh: Add retry to ssh-keyscan

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -85,6 +85,11 @@ runs:
         HOSTS: ${{ inputs.hosts }}
       run: |
         for host in $HOSTS; do
-          ssh-keyscan $host >> ~/.ssh/known_hosts
+          # Retry once if ssh-keyscan fails to try avoid transient errors
+          if ! ssh-keyscan $host >> ~/.ssh/known_hosts; then
+            echo "Retrying ssh-keyscan for $host in 5s..."
+            sleep 5
+            ssh-keyscan $host >> ~/.ssh/known_hosts
+          fi
         done
         chmod 600 ~/.ssh/known_hosts


### PR DESCRIPTION
Retry the ssh-keyscan command to see if it avoids transient errors when scanning Gadi

Related to https://github.com/ACCESS-NRI/model-config-tests/issues/207