### PR TITLE
setup-ssh: Increase timeouts and add verbose logging

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -86,11 +86,13 @@ runs:
       run: |
         for host in $HOSTS; do
           for attempt in {1..5}; do
-            if ssh-keyscan -T 10 $host >> ~/.ssh/known_hosts; then
+            if ssh-keyscan -T 30 $host >> ~/.ssh/known_hosts; then
               break
             fi
             if [[ $attempt -eq 5 ]]; then
               echo "::error::ssh-keyscan failed for $host after 5 attempts"
+              # Log verbose output of ssh-keyscan for debugging
+              ssh-keyscan -v -T 30 $host
               exit 1
             fi
             echo "Retrying ssh-keyscan for $host in 5s..."


### PR DESCRIPTION
Implemented recommendation in comment by @atteggiani: https://github.com/ACCESS-NRI/model-config-tests/issues/207#issuecomment-4323994204

- Increased timeout to 30s
- When every retry fails, run command with verbose logging. 

Related to #55. 

I am wondering whether it's possible to just save the output of `ssh-keyscan $host` as a repository secret? 

