### PR TITLE
Update setup-ssh action

### DIFF
--- a/.github/actions/setup-ssh/README.md
+++ b/.github/actions/setup-ssh/README.md
@@ -1,6 +1,6 @@
 # SSH Action
 
-This action sets up `ssh` to use a given key, and adds to `~/.ssh/known_hosts`.
+This action sets up `ssh` to use a given key.
 
 > [!IMPORTANT]  
 > If the `private-key-passphrase` input is not provided, the SSH key (`private-key`) must have been created with no (empty) passphrase, otherwise SSH authentication will fail.
@@ -9,18 +9,22 @@ This action sets up `ssh` to use a given key, and adds to `~/.ssh/known_hosts`.
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
-| hosts | string | Newline-separated list of hosts for ssh-keyscan lookup | false | N/A | 'localhost' |
-| private-key | string | Raw private key to add | true | N/A | '---- OPENSSH PRIVATE KEY ---- ...' |
-| private-key-name | string | Name of the ephemeral private key file to store in `~/.ssh` | false | 'priv.key' | 'key.pem' | 
-| private-key-passphrase | string | Passphrase of the private key. If a passphrase is not provided, the private-key must have been created with no (empty) passphrase for the `ssh` command not to fail | false | '' | 'mysecretpassphrase' |
+| hosts | string | Space- or newline-separated list of SSH hosts added to the SSH config. Each entry can optionally include an alias using the format `host:alias`, allowing connection with `ssh user@myalias` instead of `ssh user@myhost.org.au`. | YES | N/A | `myhost.org.au`, `myhost.org.au myotherhost.com:myotherhostalias` |
+| private-key | string | Raw private key to add | YES | N/A | '---- OPENSSH PRIVATE KEY ---- ...' |
+| user | string | Default user for SSH connections. When provided, it is added to the SSH config to allow connection with `ssh myhost.org.au` instead of `ssh user@myhost.org.au`. | NO | N/A | `myuser` |
+| private-key-name | string | Name of the ephemeral private key file to store in `~/.ssh` | NO | `priv.key` | `key.pem` | 
+| private-key-passphrase | string | Passphrase of the private key. If a passphrase is not provided, the private-key must have been created with no (empty) passphrase for the `ssh` command not to fail | NO | N/A | `mysecretpassphrase` |
 
 ## Outputs
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| private-key-path | string | Path to the generated private key file for use in the job | '~/.ssh/priv.key' |
+| private-key-path | string | Path to the generated private key file for use in the job | `~/.ssh/priv.key` |
 
 ## Example usage
+
+<details>
+<summary><b>Basic usage</b></summary>
 
 ```yaml
 # ...
@@ -28,15 +32,18 @@ steps:
   - id: ssh
     uses: access-nri/actions/.github/actions/setup-ssh@main
     with:
-      hosts: |
-        host1.example.com
-        host2.example.com
+      hosts: host1.example.com
       private-key: ${{ secrets.PRIVATE_KEY }} # Key with empty passphrase
   - run: |
       ssh user@host1.example.com -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
       echo "Hello from host1!"
       EOT
 ```
+
+</details>
+
+<details>
+<summary><b>With passphrase</b></summary>
 
 ```yaml
 # ...
@@ -50,7 +57,52 @@ steps:
       private-key: ${{ secrets.PRIVATE_KEY }}
       private-key-passphrase: ${{ secrets.PRIVATE_KEY_PASSPHRASE }}
   - run: |
-      ssh user@host1.example.com -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+      ssh user@host2.example.com /bin/bash <<'EOT'
+      echo "Hello from host2!"
+      EOT
+```
+
+</details>
+
+<details>
+<summary><b>Host with alias</b></summary>
+
+```yaml
+# ...
+steps:
+  - id: ssh
+    uses: access-nri/actions/.github/actions/setup-ssh@main
+    with:
+      hosts: |
+        host1.example.com:myalias
+        host2.example.com
+      private-key: ${{ secrets.PRIVATE_KEY }}
+  - run: |
+      ssh user@myalias /bin/bash <<'EOT'
       echo "Hello from host1!"
       EOT
 ```
+
+</details>
+
+<details>
+<summary><b>Host with alias and user</b></summary>
+
+```yaml
+# ...
+steps:
+  - id: ssh
+    uses: access-nri/actions/.github/actions/setup-ssh@main
+    with:
+      hosts: |
+        host1.example.com
+        host2.example.com:myotheralias
+      user: myusername
+      private-key: ${{ secrets.PRIVATE_KEY }}
+  - run: |
+      ssh myotheralias /bin/bash <<'EOT'
+      echo "Hello from host2!"
+      EOT
+```
+
+</details>

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,12 +1,20 @@
 name: Setup SSH
-description: Action to setup SSH connection and update known_hosts at the job level
+description: Action to setup SSH connection at the job level
 inputs:
   hosts:
-    required: false
-    description: A list of hosts to add to ~/.ssh/known_hosts
+    required: true
+    description: |
+      Space- or newline-separated list of SSH hosts to add to the SSH config. Each entry can optionally
+      include an alias using the format `host:alias` (e.g. `myhost.org.au:myalias`), allowing
+      connection with `ssh user@myalias` instead of `ssh user@myhost.org.au`.
   private-key:
     required: true
     description: Private key as a string
+  user:
+    required: false
+    description: |
+      Default user for SSH connections. When provided, it is added to the SSH config to allow
+      connection with `ssh myhost.org.au` instead of `ssh user@myhost.org.au`.
   private-key-name:
     required: false
     description: name of ephemeral generated private key file
@@ -21,6 +29,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Sanity check on hosts input
+      shell: bash
+      env:
+        HOSTS: ${{ inputs.hosts }}
+      run: |
+        for host in "$HOSTS"; do
+          if ! [[ "$host" =~ ^[^:]+(:[^:]+)?$ ]]; then
+            echo "::error::Invalid host entry '$host'. Each entry in 'hosts' must be in the format 'hostname' or 'hostname:alias'."
+            exit 1
+          fi
+        done
     - name: Add ~/.ssh directory
       shell: bash
       run: |
@@ -78,25 +97,24 @@ runs:
         # in the job using this action can use the same ssh-agent
         echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
         echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
-    - name: Add to known_hosts
-      if: inputs.hosts != ''
-      shell: bash
+    - name: Add hosts to ssh config
       env:
         HOSTS: ${{ inputs.hosts }}
+        USER: ${{ inputs.user }}
+      shell: bash
       run: |
-        for host in $HOSTS; do
-          for attempt in {1..5}; do
-            if ssh-keyscan -T 30 $host >> ~/.ssh/known_hosts; then
-              break
-            fi
-            if [[ $attempt -eq 5 ]]; then
-              echo "::error::ssh-keyscan failed for $host after 5 attempts"
-              # Log verbose output of ssh-keyscan for debugging
-              ssh-keyscan -v -T 30 $host
-              exit 1
-            fi
-            echo "Retrying ssh-keyscan for $host in 5s..."
-            sleep 5
-          done
+        hosts=$(echo "$HOSTS" | tr '\n' ' ' | xargs)
+        for host in $hosts; do
+          # Split the host by colon to separate the hostname from the alias (if any)
+          # If no alias is provided, the hostname and alias will be the same, which
+          # would still work fine
+          hostname=$(echo "$host" | cut -d: -f1)
+          alias=$(echo "$host" | cut -d: -f2)
+          cat >> ~/.ssh/config <<EOF
+        Host $alias
+          Hostname $hostname
+          StrictHostKeyChecking accept-new
+          IdentityFile ${{ steps.pk.outputs.path }}
+          ${USER:+User $USER}
+        EOF
         done
-        chmod 600 ~/.ssh/known_hosts

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -9,9 +9,9 @@ on:
       - '.github/workflows/test-setup-ssh.yml'
 
 env:
-    TESTED_ACTION: "setup-ssh"
-    PRIVATE_KEY: "/tmp/id_test"
-    PRIVATE_KEY_NO_PASSPHRASE: "/tmp/id_test_no_passphrase"
+  TESTED_ACTION: "setup-ssh"
+  PRIVATE_KEY: "/tmp/id_test"
+  PRIVATE_KEY_NO_PASSPHRASE: "/tmp/id_test_no_passphrase"
 
 jobs:
   # Generate ephemeral SSH keys for testing
@@ -159,7 +159,6 @@ jobs:
           ssh -vvv \
             -i '${{ steps.run-action.outputs.private-key-path }}' \
             -p 2222 \
-            -o StrictHostKeyChecking=${{ matrix.input-hosts == '' && 'no' || 'yes' }} \
             ${{ env.TEST_USERNAME }}@localhost \
             exit 0
 
@@ -185,12 +184,23 @@ jobs:
           private-key: "${{ secrets.SSH_KEY }}"
           private-key-passphrase: "${{ secrets.PASSPHRASE }}"
       
-      # We try to connect with '-o StrictHostKeyChecking=yes' to verify that the SSH key is
-      # correctly added to the known_hosts
       - name: Verify SSH connection
         run: |
           ssh -vvv \
             -i '${{ steps.run-action.outputs.private-key-path }}' \
-            -o StrictHostKeyChecking=yes \
+            ${{ secrets.USER }}@${{ secrets.HOST }} \
+            exit 0
+      
+      - name: Run action no-host
+        id: run-action-no-host
+        uses: ./.github/actions/setup-ssh
+        with: 
+          private-key: "${{ secrets.SSH_KEY }}"
+          private-key-passphrase: "${{ secrets.PASSPHRASE }}"
+      
+      - name: Verify SSH connection
+        run: |
+          ssh -vvv \
+            -i '${{ steps.run-action-no-host.outputs.private-key-path }}' \
             ${{ secrets.USER }}@${{ secrets.HOST }} \
             exit 0

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -66,7 +66,7 @@ jobs:
             label: "Passphrase"
             description: |
               Test action with SSH key with passphrase.
-            input-hosts: ""
+            input-hosts: "localhost"
             input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
             input-private-key-name: "id_test"
             input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
@@ -75,7 +75,7 @@ jobs:
             label: "No passphrase"
             description: |
               Test action with SSH key without passphrase.
-            input-hosts: ""
+            input-hosts: "localhost"
             input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
             input-private-key-name: "id_test"
             input-private-key-passphrase: ""
@@ -84,7 +84,7 @@ jobs:
             label: "Failure - wrong passphrase provided"
             description: |
               Test action with wrong passphrase provided.
-            input-hosts: ""
+            input-hosts: "localhost"
             input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
             input-private-key-name: "id_test"
             input-private-key-passphrase: "wrong_passphrase"
@@ -93,7 +93,7 @@ jobs:
             label: "Failure - no passphrase provided"
             description: |
               Test action with no passphrase provided when needed.
-            input-hosts: ""
+            input-hosts: "localhost"
             input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key }}"
             input-private-key-name: "id_test"
             input-private-key-passphrase: ""
@@ -102,11 +102,38 @@ jobs:
             label: "Passphrase provided when not needed"
             description: |
               Test action with passphrase provided when not needed.
-            input-hosts: ""
+            input-hosts: "localhost"
             input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
             input-private-key-name: "id_test"
             input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
             outcome: "success"
+          - id: 6
+            label: "Alias wrong format"
+            description: |
+              Test action with alias in wrong format.
+            input-hosts: "localhost:"
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
+            outcome: "failure"
+          - id: 7
+            label: "Alias wrong format 2"
+            description: |
+              Test action with alias in wrong format.
+            input-hosts: ":localhost"
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
+            outcome: "failure"
+          - id: 8
+            label: "Alias wrong format 3"
+            description: |
+              Test action with alias in wrong format.
+            input-hosts: "localhost::myalias"
+            input-private-key: "${{ needs.generate-ssh-keys.outputs.private-key-no-passphrase }}"
+            input-private-key-name: "id_test"
+            input-private-key-passphrase: "${{ needs.generate-ssh-keys.outputs.passphrase }}"
+            outcome: "failure"
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -159,17 +186,15 @@ jobs:
           ssh -vvv \
             -i '${{ steps.run-action.outputs.private-key-path }}' \
             -p 2222 \
-            ${{ env.TEST_USERNAME }}@localhost \
+            $TEST_USERNAME@localhost \
             exit 0
 
       - name: Cleanup SSH server
         if: always()
         run: docker rm -f test-ssh-server 2>/dev/null || true
     
-  # To test with the hosts input we need a real world scenario with a real SSH server, 
-  # so we cannot use the same ephemeral SSH keys generated for the previous job.
   test-real-host:
-    name: Test real host with passphrase
+    name: Test real host
     runs-on: ubuntu-latest
     environment: test-setup-ssh
     steps:
@@ -180,27 +205,55 @@ jobs:
         id: run-action
         uses: ./.github/actions/setup-ssh
         with: 
-          hosts: ${{ secrets.HOST }}
+          hosts: |
+            ${{ secrets.HOST }}
+            another_host
           private-key: "${{ secrets.SSH_KEY }}"
           private-key-passphrase: "${{ secrets.PASSPHRASE }}"
       
       - name: Verify SSH connection
-        run: |
-          ssh -vvv \
-            -i '${{ steps.run-action.outputs.private-key-path }}' \
-            ${{ secrets.USER }}@${{ secrets.HOST }} \
-            exit 0
-      
-      - name: Run action no-host
-        id: run-action-no-host
+        run: ssh -vvv ${{ secrets.USER }}@${{ secrets.HOST }} exit 0
+  
+  test-user-input:
+    name: Test user input
+    runs-on: ubuntu-latest
+    environment: test-setup-ssh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run action
+        id: run-action
         uses: ./.github/actions/setup-ssh
         with: 
+          hosts: |
+            ${{ secrets.HOST }}
+            another_host
+          user: ${{ secrets.USER }}
           private-key: "${{ secrets.SSH_KEY }}"
           private-key-passphrase: "${{ secrets.PASSPHRASE }}"
       
       - name: Verify SSH connection
-        run: |
-          ssh -vvv \
-            -i '${{ steps.run-action-no-host.outputs.private-key-path }}' \
-            ${{ secrets.USER }}@${{ secrets.HOST }} \
-            exit 0
+        run: ssh -vvv ${{ secrets.HOST }} exit 0
+  
+  test-alias:
+    name: Test host alias
+    runs-on: ubuntu-latest
+    environment: test-setup-ssh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run action
+        id: run-action
+        uses: ./.github/actions/setup-ssh
+        with: 
+          hosts: |
+            ${{ secrets.HOST }}:myalias
+            another_host
+          user: ${{ secrets.USER }}
+          private-key: "${{ secrets.SSH_KEY }}"
+          private-key-passphrase: "${{ secrets.PASSPHRASE }}"
+      
+      - name: Verify SSH connection
+        run: ssh -vvv myalias exit 0


### PR DESCRIPTION
Updated setup SSH action with the following:

- [x] Changed `hosts` input to be compulsory and not optional
- [x] Add ssh config entry for each host with `IdentityFile` to facilitate SSH connections without needing to specify the identity
- [x] Allow the specification of hosts with aliases (in the form `host:alias`) to facilitate SSH connection using `ssh user@alias` instead of `ssh user@host.example.com`
- [x] Add the optional `user` input, to facilitate SSH connection using `ssh host.example.com` instead of `ssh user@host.example.com` (together with the alias function above, this could allow connections only using `ssh alias`)
- [x] Updated tests 
- [x] Updated README

Latest [successful test](https://github.com/ACCESS-NRI/actions/actions/runs/25413461152)

> [!IMPORTANT]
> The change of the `hosts` input to be compulsory makes these updates non back-compatible. This might not be a problem as I don't think this action is currently being used without specifying any host. 
> However, if you think this could lead to problems, we can find ways around it.
