### PR TITLE
Update conda package action to version 3.1.0

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Publish package to Anaconda.org
         id: publish-conda-package
         if: ${{ inputs.conda-package }}
-        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.0.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.1.0
         with:
           meta_yaml_dir: ${{ steps.create-recipe.outputs.meta-yaml-dir }}
           user: ${{ secrets.ANACONDA_USERNAME }}


### PR DESCRIPTION
Bumped the version of the conda packaging action to includes the recent changes deprecating the use of `conda build` in favor of `conda-build`.