### PR TITLE
Fixes setup-ssh action

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -97,6 +97,14 @@ runs:
         # in the job using this action can use the same ssh-agent
         echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
         echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
+    # In the ssh config we set for each host:
+    # StrictHostKeyChecking accept-new - To automatically accept new host keys
+    # IdentityFile <path> - The private ssh key to be used
+    # ConnectTimeout 60 - Avoid hanging indefinitely if the server is unreachable.
+    # ServerAliveInterval 60 - Send a "probe" every minute to verify that the connection is
+    #                          still active. Avoid keeping stale connections
+    # ServerAliveCountMax 3 - After 3 failed "probes", the connection will be closed.
+    # User <user> - User only if the user input is provided
     - name: Add hosts to ssh config
       env:
         HOSTS: ${{ inputs.hosts }}
@@ -115,6 +123,9 @@ runs:
           Hostname $hostname
           StrictHostKeyChecking accept-new
           IdentityFile ${{ steps.pk.outputs.path }}
+          ConnectTimeout 60
+          ServerAliveInterval 60
+          ServerAliveCountMax 3
           ${USER:+User $USER}
         EOF
         done

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - '.github/actions/setup-ssh/action.yml'
-      - '.github/workflows/test-setup-ssh.yml'
+      - '.github/workflows/test-setup-ssh-action.yml'
 
 env:
   TESTED_ACTION: "setup-ssh"
@@ -257,3 +257,28 @@ jobs:
       
       - name: Verify SSH connection
         run: ssh -vvv myalias exit 0
+  
+  # We test that the connection providing the ssh key with `-i <private-key-path>` still works
+  test-legacy:
+    name: Test connection
+    runs-on: ubuntu-latest
+    environment: test-setup-ssh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run action
+        id: run-action
+        uses: ./.github/actions/setup-ssh
+        with: 
+          hosts: |
+            ${{ secrets.HOST }}
+            another_host
+          private-key: "${{ secrets.SSH_KEY }}"
+          private-key-passphrase: "${{ secrets.PASSPHRASE }}"
+      
+      - name: Verify SSH connection
+        run: |
+          ssh -vvv ${{ secrets.USER }}@${{ secrets.HOST }} \
+            -i ${{ steps.run-action.outputs.private-key-path }} \
+            exit 0

--- a/.github/workflows/test-setup-ssh-action.yml
+++ b/.github/workflows/test-setup-ssh-action.yml
@@ -260,7 +260,7 @@ jobs:
   
   # We test that the connection providing the ssh key with `-i <private-key-path>` still works
   test-legacy:
-    name: Test connection
+    name: Test legacy connection
     runs-on: ubuntu-latest
     environment: test-setup-ssh
     steps:


### PR DESCRIPTION
- [x] Added test for legacy ssh connection
- [x] Updates to the `setup-ssh` action to add the following ssh config settings:
   - `ConnectTimeout 60` --> Avoids hanging indefinitely if the server is unreachable.
   - `ServerAliveInterval 60` --> Checks every 60s if the connection is still active, to avoid stale connections
   - `ServerAliveCountMax 3` --> After 3 failed checks above, the connection will be closed.
   These as a whole avoid keeping a stale connection to a server active (avoiding wasting GitHub runner time).