### PR TITLE
Update artifacts structure

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ This workflow builds and publishes a pure python package distribution on Pypi an
 > This workflow does not support [PyPI Trusted Publisher](https://docs.pypi.org/trusted-publishers/) technology, as [it cannot be used within a reusable workflow at this time](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing). Therefore, a PyPI token is required to publish to PyPI.
 
 ### About
-This workflow builds a Python wheel and source tarball from the project’s `pyproject.toml`, generates a conda recipe using [Grayskull](https://github.com/conda/grayskull), and builds the corresponding conda package. It then publishes the wheel to PyPI and the conda package to Anaconda.org, while also uploading an artifact containing the wheel, conda package, and tarball for further use.
+This workflow builds a Python wheel and source tarball from the project’s `pyproject.toml`, generates a conda recipe using [Grayskull](https://github.com/conda/grayskull), and builds the corresponding conda package. It then publishes the wheel to PyPI and the conda package to Anaconda.org. It also uploads the `python-package` and `conda-package` artifacts, containing the python packages, and conda packages and recipe, respectively.
 
 ### Inputs
 
@@ -58,7 +58,8 @@ This workflow builds a Python wheel and source tarball from the project’s `pyp
 
 | Name | Type | Description | Example |
 | --- | --- | --- | --- |
-| artifact-name | string | The name of the artifact containing the built packages and tarball | `_dist_artifact` |
+| python-artifact-name | string | The name of the artifact containing the built python packages | `python-package` |
+| conda-artifact-name | string | The name of the artifact containing the built conda packages and recipe | `conda-package` |
 
 ### Usage
 

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -39,12 +39,6 @@ env:
   PYTHON_ARTIFACT_DIR: ${{ github.workspace }}/_python_artifact_dir
   CONDA_ARTIFACT_NAME: conda_package
   BUILD_ENV_FILE: ${{ github.workspace }}/build_environment.yaml
-<<<<<<< HEAD
-  ARTIFACT_NAME: _dist_artifact
-  ARTIFACT_DIR: ${{ github.workspace }}/_dist_artifact_dir
-=======
-  BUILD_ENV_NAME: build-env
->>>>>>> 80c8527 (Updated artifact structure to separate conda and python artifacts)
 
 jobs:
   inputs_sanity_check:

--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -17,9 +17,12 @@ on:
         default: true
         description: "Whether to create the Conda package and publish it to Anaconda.org"
     outputs:
-      artifact-name:
-        description: "The name of the artifact containing the built packages and tarball"
-        value: ${{ jobs.upload-artifact.outputs.artifact-name }}
+      python-artifact-name:
+        description: "The name of the artifact containing the built python packages"
+        value: ${{ jobs.publish-package.outputs.python-artifact-name }}
+      conda-artifact-name:
+        description: "The name of the artifact containing the built conda packages and recipe"
+        value: ${{ jobs.publish-package.outputs.conda-artifact-name }}
     secrets:
       PYPI_TOKEN:
         description: "The PyPI token used for publishing the Python package on PyPI"
@@ -32,13 +35,16 @@ on:
         required: false
 
 env:
-  PYTHON_ARTIFACT_NAME: _python_artifact
+  PYTHON_ARTIFACT_NAME: python_package
   PYTHON_ARTIFACT_DIR: ${{ github.workspace }}/_python_artifact_dir
-  CONDA_ARTIFACT_NAME: _conda_artifact
-  CONDA_ARTIFACT_DIR: ${{ github.workspace }}/_conda_artifact_dir
+  CONDA_ARTIFACT_NAME: conda_package
   BUILD_ENV_FILE: ${{ github.workspace }}/build_environment.yaml
+<<<<<<< HEAD
   ARTIFACT_NAME: _dist_artifact
   ARTIFACT_DIR: ${{ github.workspace }}/_dist_artifact_dir
+=======
+  BUILD_ENV_NAME: build-env
+>>>>>>> 80c8527 (Updated artifact structure to separate conda and python artifacts)
 
 jobs:
   inputs_sanity_check:
@@ -106,8 +112,8 @@ jobs:
               exit 1
           fi
 
-  build_tarball_and_python_wheel:
-    name: Build tarball and Python wheel
+  build_tarball:
+    name: Build tarball
     runs-on: ubuntu-latest
     needs: inputs_sanity_check
     steps:
@@ -124,7 +130,7 @@ jobs:
             --outdir '${{ env.PYTHON_ARTIFACT_DIR }}' \
             '${{ needs.inputs_sanity_check.outputs.pyproject_toml_dir }}'
           echo Built files:
-          ls -l '${{ env.PYTHON_ARTIFACT_DIR }}' | tail -n -1
+          ls -l '${{ env.PYTHON_ARTIFACT_DIR }}'
 
       - uses: actions/upload-artifact@v7
         with:
@@ -134,7 +140,10 @@ jobs:
   publish-package:
     name: Publish package
     runs-on: ubuntu-latest
-    needs: [inputs_sanity_check, build_tarball_and_python_wheel]
+    needs: [inputs_sanity_check, build_tarball]
+    outputs:
+      python-artifact-name: ${{ steps.set-artifact-name-outputs.outputs.python-artifact-name }}
+      conda-artifact-name: ${{ steps.set-artifact-name-outputs.outputs.conda-artifact-name }}
     steps:
       - uses: actions/checkout@v6
       
@@ -211,7 +220,9 @@ jobs:
         if: ${{ inputs.conda-package }}
         with:
           name: ${{ env.CONDA_ARTIFACT_NAME }}
-          path: ${{ steps.publish-conda-package.outputs.paths }}
+          path: |
+            ${{ steps.publish-conda-package.outputs.paths }}
+            ${{ steps.create-recipe.outputs.meta-yaml-dir }}/meta.yaml
         
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
@@ -220,64 +231,9 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: ${{ env.PYTHON_ARTIFACT_DIR }}
           verbose: true
-    
-  upload-artifact:
-    name: Upload artifact with tarball and built packages
-    runs-on: ubuntu-latest
-    needs: [publish-package]
-    # Run job if any needed job succeded, even if others are skipped or cancelled. 
-    # Don't run if any needed job failed or no jobs succeded (all skipped or cancelled).
-    if: ${{ always() && ! contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
-    env:
-      GH_TOKEN: ${{ github.token }}
-    outputs:
-      artifact-name: ${{ steps.set-output-artifact-name.outputs.artifact-name }}
-    steps:
-      # To avoid downloading artifacts produced by previous steps, we download the desired artifacts separately 
-      - name: Download python artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.PYTHON_ARTIFACT_NAME }}
-          path: ${{ env.PYTHON_ARTIFACT_DIR }}
-      
-      - name: Download conda artifact
-        if: ${{ inputs.conda-package }}
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.CONDA_ARTIFACT_NAME }}
-          path: ${{ env.CONDA_ARTIFACT_DIR }}
-        
-      # To avoid having intermediary artifacts from previous steps
-      # we delete the python and conda artifacts
-      - name: Delete artifacts
-        run: |
-          for artifact_name in '${{ env.PYTHON_ARTIFACT_NAME }}' '${{ env.CONDA_ARTIFACT_NAME }}'; do
-            # Get the artifact ID
-            artifact_id=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-                --jq ".artifacts[] | select(.name==\"$artifact_name\") | .id")
-            # Delete the artifact
-            if [ -n "$artifact_id" ]; then
-                gh api --method DELETE repos/${{ github.repository }}/actions/artifacts/$artifact_id &> /dev/null \
-                  && echo "Deleted artifact '$artifact_name'." \
-                  || echo "::warning::No permissions to delete artifact '$artifact_name'. Please run the workflow with \`permissions: actions: write\`"
-            else
-                echo "Artifact '$artifact_name' not found."
-            fi
-          done
 
-      - name: Create output artifact directory
+      - name: Set artifact name outputs
+        id: set-artifact-name-outputs
         run: |
-          mkdir -p ${{ env.ARTIFACT_DIR }}
-          mv ${{ env.PYTHON_ARTIFACT_DIR }}/* ${{ env.ARTIFACT_DIR }}
-          if [ '${{ inputs.conda-package }}' = 'true' ]; then
-            mv ${{ env.CONDA_ARTIFACT_DIR }}/* ${{ env.ARTIFACT_DIR }}
-          fi
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.ARTIFACT_DIR }}/*
-    
-      - name: Set output artifact name
-        id: set-output-artifact-name
-        run: echo "artifact-name=${{ env.ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
+          echo "python-artifact-name=${{ env.PYTHON_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
+          echo "conda-artifact-name=${{ env.CONDA_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Update artifacts structure to simplify artifacts uploading and separate python and conda artifacts. 

- [x] Replaced single artifact with two separate artifacts: `python_package` and `conda_package`.
- [x] Added conda recipe to the `conda_package` artifact
- [x] Added `conda-artifact-name` and `python-artifact-name` outputs containing the names of the artifacts for easier download within a workflow. 


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>